### PR TITLE
ci: trigger actions less

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
I don't need tests triggered when I push to a branch on this repo before I create a pull request.