### PR TITLE
maint: prep for next release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,27 +56,22 @@ jobs:
     - name: Download Clojure Dependencies
       run: bb download-deps
 
-    - name: Release Prep (step 1 of 4)
+    - name: Release Prep (step 1 of 5)
       run: bb ci-release prep
 
-    - name: Release Deploy (step 2 of 4)
+    - name: Release Deploy (step 2 of 5)
       env:
         CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
         CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
       run: bb ci-release deploy-remote
 
-    - name: Release Commit (step 3 of 4)
+    - name: Release Commit (step 3 of 5)
       run: bb ci-release commit
 
-    - name: Make GitHub Actions aware of target version tag
-      run: echo "tag=v$(clojure -T:build built-version)" >> $GITHUB_OUTPUT
-      id: target-version
-
-    - name: Create GitHub release (step 4 of 4)
-      uses: actions/create-release@v1
+    - name: Create GitHub Release (step 4 of 5)
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.target-version.outputs.tag}}
-        release_name: ${{ steps.target-version.outputs.tag}}
-        commitish: main
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: bb ci-release create-github-release
+
+    - name: Inform Cljdoc (step 5 of 5)
+      run: bb ci-release inform-cljdoc

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,20 +1,27 @@
 // NOTE: release process automatically updates titles with "Unreleased" to title with actual release version
 = Change Log
 
-For a list of breaking changes see link:#breaking[breaking-changes]
+[.normal]
+A release with known breaking changes is marked with:
 
-// Release workflow will:
-// - Fail if there is no "== Unreleased" section header
-// - Helpfully fail when the section contains no descriptive text
-// - Replace the Unreleased section header with actual release version
-// - Prepend a new Unreleased section header
+* [breaking] you probably need to change your code
+* [minor breaking] you likely don't need to change your code
+
+// DO NOT EDIT: the "Unreleased" section header is automatically updated by the release workflow
+// which will fail on any of:
+// - unreleased section not found,
+// - unreleased section empty
+// - optional attribute is not [breaking] or [minor breaking]
+//   (adjust these in ci_relase.clj as you see fit)
 
 == Unreleased
 
+* Drop `alpha` status, we don't have many users, but folks have been using this lib for years
+* Reviewed and refreshed docs
 * Bumped library deps (these are used during test generation only)
-* No longer engaging clj-kondo's lint feature during code analysis.
+* No longer engaging clj-kondo's lint feature during code analysis
 
-== v1.0.166-alpha
+== v1.0.166-alpha - 2021-11-27 [[v1.0.166-alpha]]
 
 * While preserving our existing `-X` command line interface, add a more conventional main command line interface to support leiningen (and potentially Windows) users https://github.com/lread/test-doc-blocks/issues/8[#8]
 * Now failing when a requested file/glob does not exist https://github.com/lread/test-doc-blocks/issues/9[#9]
@@ -22,101 +29,90 @@ For a list of breaking changes see link:#breaking[breaking-changes]
 * Internal test-doc-blocks developer facing:
 ** Migrate from `depstar` to `tools.build`
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.146-alpha\...v1.0.166-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.146-alpha\...v1.0.166-alpha[commit log]
 
-== v1.0.146-alpha
+== v1.0.146-alpha - 2021-08-30 [[v1.0.146-alpha]]
 
 * Add support for `(refer-clojure ...)` in doc blocks https://github.com/lread/test-doc-blocks/issues/5[#5]
 * Bump rewrite-clj to v1.0.682-alpha
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.137-alpha\...v1.0.146-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.137-alpha\...v1.0.146-alpha[commit log]
 
-== v1.0.137-alpha
+== v1.0.137-alpha - 2021-08-23 [[v1.0.137-alpha]]
 
 * Freshen up docs, deps and internal scripts
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.129-alpha\...v1.0.137-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.129-alpha\...v1.0.137-alpha[commit log]
 
-== v1.0.129-alpha
+== v1.0.129-alpha - 2021-04-16 [[v1.0.129-alpha]]
 
 * Maintenance release - bump deps
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.124-alpha\...v1.0.129-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.124-alpha\...v1.0.129-alpha[commit log]
 
-== v1.0.124-alpha
+== v1.0.124-alpha - 2021-03-26 [[v1.0.124-alpha]]
 
 * Maintenance release - deps, docs and ops updates
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.116-alpha\...v1.0.124-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.116-alpha\...v1.0.124-alpha[commit log]
 
-== v1.0.116-alpha
+== v1.0.116-alpha - 2021-03-17 [[v1.0.116-alpha]]
 
 * Switch to `com.github.lread/test-doc-blocks` for deployment artifact name as per new security measures at clojars.
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.114-alpha\...v1.0.116-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.114-alpha\...v1.0.116-alpha[commit log]
 
-== v1.0.114-alpha
+== v1.0.114-alpha - 2021-03-14 [[v1.0.114-alpha]]
 
 * Ensure test-doc-blocks works on Windows
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.107-alpha\...v1.0.114-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.107-alpha\...v1.0.114-alpha[commit log]
 
-== v1.0.107-alpha
+== v1.0.107-alpha - 2021-03-13 [[v1.0.107-alpha]]
 
 * Support generating tests from CommonMark code blocks found in Clojure source docstrings
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.103-alpha\...v1.0.107-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.103-alpha\...v1.0.107-alpha[commit log]
 
-== v1.0.103-alpha
+== v1.0.103-alpha - 2021-03-12 [[v1.0.103-alpha]]
 
 * Correct sort order in new tree-like report of found blocks
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.101-alpha\...v1.0.103-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.101-alpha\...v1.0.103-alpha[commit log]
 
-== v1.0.101-alpha
+== v1.0.101-alpha - 2021-03-11 [[v1.0.101-alpha]]
 
 * Don't trim trailing newline for test body if last item is comment
 * Switch from (too) wide table to tree-like report of found blocks
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.92-alpha\...v1.0.101-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.92-alpha\...v1.0.101-alpha[commit log]
 
-== v1.0.92-alpha
+== v1.0.92-alpha - 2021-03-11 [[v1.0.92-alpha]]
 
 * Upgraded from rewrite-clj v0 to rewrite-clj v1
 * Release workflow now creates a GitHub release
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.85-alpha\...v1.0.92-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.85-alpha\...v1.0.92-alpha[commit log]
 
-== v1.0.85-alpha
+== v1.0.85-alpha - 2021-02-06 [[v1.0.85-alpha]]
 
 * Correct public API for cljdoc
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.82-alpha\...v1.0.85-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.82-alpha\...v1.0.85-alpha[commit log]
 
-== v1.0.82-alpha
+== v1.0.82-alpha - 2021-02-06 [[v1.0.82-alpha]]
 
 * Developer facing only: more updates to release workflow
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.80-alpha\...v1.0.82-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.80-alpha\...v1.0.82-alpha[commit log]
 
-== v1.0.80-alpha
+== v1.0.80-alpha - 2021-02-06 [[v1.0.80-alpha]]
 
 * Developer facing only: updates to release workflow
 
-https://github.com/lread/test-doc-blocks/compare/v1.0.76-alpha\...v1.0.80-alpha[Gritty details of changes for this release]
+https://github.com/lread/test-doc-blocks/compare/v1.0.76-alpha\...v1.0.80-alpha[commit log]
 
-== v1.0.76-alpha
+== v1.0.76-alpha - 2021-02-05 [[v1.0.72-alpha]]
 
 * First release
 
-[#breaking]
-== Breaking Changes
-
-// Release workflow will:
-// - If an "=== Unreleased Breaking Changes" section header exists here:
-//   - Helpfully fail the section contains no descriptive text
-//   - Replace the Unreleased section header with actual release version
-
-Still in alpha, nothing to track yet!
-
-// === Unreleased Breaking Changes

--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ toc::[]
 
 == Status
 
-Alpha - early adopters and feedback welcome!
+Folks have been using test-doc-blocks for years without issue.
 
 == Rationale
 I wanted to make sure the code examples I provided in rewrite-clj v1 documentation do not mislead and function as expected for those who dare to try them.
@@ -49,11 +49,11 @@ Have an update? Let us know!
 
 == Versioning
 
-Test-doc-block versioning scheme is: `major`.`minor`.`patch`-`test-qualifier`
+Test-doc-block versioning scheme is: `major`.`minor`.`release`-`test-qualifier`
 
 * `major` increments when the API has been broken - something, as a rule, we'd like to avoid.
 * `minor` increments to convey significant new features have been added.
-* `patch` indicates bug fixes - it is the number of commits in the repo.
+* `release` starting with v1.1, the test-doc-blocks release count over the life of test-doc-blocks.
 * `test-qualifier` is absent for stable releases. Can be `alpha`, `beta`, `rc1`, etc.
 
 == People

--- a/bb.edn
+++ b/bb.edn
@@ -1,11 +1,11 @@
 {:min-bb-version "0.3.7"
- :paths ["script"]
+ :paths ["script" "build"]
  :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
         dev.nubank/docopt {:mvn/version "0.6.1-fix7"}
         version-clj/version-clj {:mvn/version "2.0.2"}
-        etaoin/etaoin {:mvn/version "1.0.40"}}
-
+        etaoin/etaoin {:mvn/version "1.0.40"}
+        io.github.babashka/neil {:git/tag "v0.3.65" :git/sha "9a79582"}}
  :tasks {;; setup
          :requires ([babashka.fs :as fs]
                     [clojure.string :as string]
@@ -114,6 +114,9 @@
 
          cljdoc-preview {:doc "preview what docs will look like on cljdoc, use --help for args"
                          :task cljdoc-preview/-main}
+
+         ;; let's not rely on a random version of neil
+         neil              {:task babashka.neil/-main     :doc "Pinned version of babashka/neil (used in scripting)"}
 
          ci-test {:doc "run continuous integration service tests"
                   :task (when (no-args-check)

--- a/build/build_shared.clj
+++ b/build/build_shared.clj
@@ -1,0 +1,21 @@
+(ns build-shared
+  "a few things that are both needed by bb script code and build.clj"
+  (:require [clojure.edn :as edn]))
+
+(defn- project-info []
+  (-> (edn/read-string (slurp "deps.edn"))
+      :aliases :neil :project))
+
+(def version-tag-prefix "v")
+
+(defn lib-version []
+  (-> (project-info) :version))
+
+(defn lib-artifact-name []
+  (-> (project-info) :name))
+
+(defn lib-github-coords []
+  (-> (project-info) :github-coords))
+
+(defn version->tag [version]
+  (str version-tag-prefix version))

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,14 @@
         metosin/malli {:mvn/version "0.16.0"}
         rewrite-clj/rewrite-clj  {:mvn/version "1.1.47"}}
 
- :aliases {;;
+ :aliases {;; we use babashka/neil for project attributes
+           ;; publish workflow references these values (and automatically bumps patch component of version)
+           :neil {:project {:version "1.1.18" ;; describes last release and is template for next release
+                            :name com.github.lread/test-doc-blocks
+                            ;; not neilisms - could potentially conflict with new neilisms
+                            :github-coords lread/test-doc-blocks}}
+
+           ;;
            ;; Clojure versions we support
            ;; min for generation is v1.9
            ;; min for running generated v1.8
@@ -77,6 +84,7 @@
            ;; Deployment
            ;;
            :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.1"}}
+                   :extra-paths ["src" "build"]
                    :ns-default build}
 
            ;; keep deploy deps separate from build deps to avoid download-deps issues

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -153,7 +153,7 @@ Before a release, it can be comforting to preview what docs will look like on ht
 Limitations
 
 * Considered this task experimental.
-I have only tested on macOS, but I am fairly confident it will work on Linux.
+I have tested on macOS and Linux.
 I'm not sure about Windows at this time.
 * You have to push your changes to GitHub to preview them.
 This allows for a full preview that includes any links (source, images, etc.) to GitHub.

--- a/doc/03-maintainer-guide.adoc
+++ b/doc/03-maintainer-guide.adoc
@@ -11,15 +11,17 @@ A release is triggered manually via a GitHub Action "Release" workflow.
 === Automated Workflow
 Our https://github.com/lread/test-doc-blocks/actions?query=workflow%3A%22Release%22[Release] GitHub Action handles the release workflow.
 
-Our GitHub Actions "Release" workflow:
+Our GitHub Actions "Release" workflow will:
 
 . Create a thin jar using our version scheme
-. Apply jar version to the following docs:
+. Apply jar version to the following files:
+.. `deps.edn` (we use babashka neil for version tracking/management)
 .. user guide docs `deps.edn` usage example
-.. change log "unreleased" and "unreleased breaking changes" headings
+.. change log "unreleased" heading
 . Deploy the jar to clojars
-. Commit and push updates made to `CHANGELOG.adoc` and `01-user-guide.adoc` back to the project
+. Commit and push updates made to `deps.edn`, `CHANGELOG.adoc` and `01-user-guide.adoc` back to the project
 . Create and push a release tag back to the project repo
+. Create a GitHub release
 . Inform cljdoc of the new release
 
 At this time, the release workflow does not run tests.
@@ -29,8 +31,9 @@ The release workflow will fail if the change log is not ready for release.
 
 === Updating the Version
 
-Edit `version.edn` in the project root.
-The release workflow consults this file when constructing the version.
+Edit `deps.edn`-> `:aliases` -> `:neil` -> `:version` in the project root.
+The release workflow automatically bumps the `:version` `patch` component by 1 before releasing.
+Update the `:version` `major` and `minor` components in `deps.edn` manually as needed.
 
 === Special Setup
 
@@ -50,7 +53,7 @@ If you so wish, you can also locally run all steps up to, but not including, dep
 ----
 bb ci-release prep
 ----
-Locally verify, but do NOT check in changes `prep` makes to `CHANGELOG.adoc`, `pom.xml` and `doc/01-user-guide.adoc`.
+Locally verify, but do NOT check in changes `prep` makes to `deps.edn`, `CHANGELOG.adoc`, and `doc/01-user-guide.adoc`.
 
 === Invoking a Release
 As a maintainer, you should have sufficient privileges to see a "Run Workflow" dropdown button on the https://github.com/lread/test-doc-blocks/actions/workflows/release.yml?query=workflow%3ARelease[Release] action page.

--- a/script/clean.clj
+++ b/script/clean.clj
@@ -5,10 +5,14 @@
             [helper.main :as main]))
 
 (defn clean! []
-  (doseq [dir ["target" ".cpcache"]]
-    (println "Deleting" dir)
-    (when (fs/exists? dir)
-      (fs/delete-tree dir))))
+  (println "Deleting (d=deleted -=did not exist)")
+  (run! (fn [d]
+          (println (format "[%s] %s"
+                           (if (fs/exists? d) "d" "-")
+                           d))
+          (fs/delete-tree d))
+        ["target"
+         ".cpcache"]))
 
 (defn -main [& args]
   (when (main/doc-arg-opt args)

--- a/version.edn
+++ b/version.edn
@@ -1,3 +1,0 @@
-{:major 1 
- :minor 0 
- :qualifier "alpha"}


### PR DESCRIPTION
Move to 1.1.<release count> version scheme.

Move to using neil to track version within `deps.edn`. I don't necessarily think this is better than the old `version.edn`, but it is consistent with what I've done on my other projects.

Tweak changelog
- move to [breaking] [minor breaking] attributes on release header scheme I've used on other projects
- automatically add yyyy-mm-dd date to release header
- describe commits for release link as "commit log"

Add GitHub release creation to release workflow.

Stick with release initiated through GitHub UI on release workflow. I still feel this is much simpler than a version tag triggered release.