### PR TITLE
docs: review inline options

### DIFF
--- a/doc/example.adoc
+++ b/doc/example.adoc
@@ -102,31 +102,35 @@ It is sometimes just nice to know that your code snippet will run without except
 == Inline Options
 You can, to some limited extent, communicate your intent to test-doc-blocks.
 
-Test-doc-blocks will look for AsciiDoc comments that begin with `:test-doc-blocks`.
+Test-doc-blocks will look for AsciiDoc `:test-doc-blocks` comment lines.
 
 It currently understands the following options:
 
-* `:test-doc-blocks/apply` - controls to what code blocks options are applied
 * `:test-doc-blocks/skip` - skips the next code block
 * `:test-doc-blocks/reader-cond` - wraps your code block in a reader conditional
 * `:test-doc-blocks/test-ns` - specifies the output test namespace
 * `:test-doc-blocks/platform` - specifies Clojure file type to generate for test ns
 * `:test-doc-blocks/meta` - attach metadata to generated tests
-
-=== Applying Options - :apply
-
-By default, test-doc-blocks will create tests for all Clojure code blocks it finds in the files you specified.
-
-You can change this by including the `:test-doc-blocks/apply` option:
-
-* `:next` - default - applies new options to next Clojure code block only
-* `:all-next` - applies new options to all subsequent code blocks in the document until specifically overridden with new opts
+* `:test-doc-blocks/apply` - controls to what code blocks options are applied
 
 === Skipping Code Blocks - :skip
 
 By default, test-doc-blocks will create tests for all Clojure code blocks it finds.
 
-Tell test-doc-blocks to skip the next Clojure code block via the following AsciiDoc comment:
+Tell test-doc-blocks to skip the next Clojure code block via `//#:test-doc-blocks {:skip true}`:
+
+[source,asciidoc]
+....
+//#:test-doc-blocks {:skip true}
+[source,clojure]
+----
+;; no tests will be generated for this code Clojure code block
+
+(something we don't want to test...
+----
+....
+
+Because `:skip` is a boolean, you can use the shorter `//:test-doc-blocks/skip`:
 
 [source,asciidoc]
 ....
@@ -135,7 +139,7 @@ Tell test-doc-blocks to skip the next Clojure code block via the following Ascii
 ----
 ;; no tests will be generated for this code Clojure code block
 
-(something we don't want to test)
+(something we don't want to test...
 ----
 ....
 
@@ -188,7 +192,8 @@ Test-doc-blocks does no special checking, but `:reader-cond` only makes sense fo
 === Specifying Test Namespace - :test-ns
 
 By default, test-doc-blocks will generate tests to namespaces based on document filenames.
-This file is named `example.adoc`. Test-doc-blocks, up to this point, has been generating tests to the `example-adoc-test` namespace.
+This file you are reading now is named `example.adoc`.
+Test-doc-blocks, up to this point, has been generating tests to the `example-adoc-test` namespace.
 
 If this does not work for you, you can override this default via an AsciiDoc comment:
 
@@ -238,7 +243,7 @@ When specifying the platform, remember that:
 * For Clojure `my-ns-file.clj` will be picked over `my-ns-file.cljc`
 * For ClojureScript `my-ns-file.cljs` will be picked over `my-ns-file.cljc`
 
-So if you are generating mixed platforms, you might want to specify the test-ns as well.
+So if you are generating mixed platforms, you might want to specify the test-ns as well:
 
 [source,asciidoc]
 ....
@@ -301,6 +306,62 @@ user=> (into [] {:a 1})
 ----
 ....
 
+=== Applying Options - :apply
+
+Use the `:test-doc-blocks/apply` option to control which code blocks your specified option(s) apply to:
+
+* `:next` - default - applies new options to next Clojure code block only
+* `:all-next` - applies new options to all subsequent code blocks in the document until specifically overridden with new opts
+
+For example, maybe you want test-doc-blocks to skip code blocks by default:
+
+[source,asciidoc]
+....
+//#:test-doc-blocks{:skip true :apply :all-next}
+....
+
+All subsequent code blocks would be skipped.
+
+[source,asciidoc]
+....
+[source,clojure]
+----
+;; I am a code block that is skipped by test-doc-blocks
+(maybe some code that won't compile ...
+----
+....
+
+Then you could choose to not skip a code block like so:
+[source,asciidoc]
+....
+//#:test-doc-blocks{:skip false}
+[source,clojure]
+----
+;; A test will be generated for this code block
+(apply str (interpose " " ["don't" "skip" "me!"]))
+;; =>  "don't skip me!"
+----
+....
+
+To have test-doc-blocks stop skipping code blocks by default:
+
+[source,asciidoc]
+....
+//#:test-doc-blocks{:skip false :apply :all-next}
+....
+
+And now test-doc-blocks will generate tests for subsequent code blocks.
+
+[source,asciidoc]
+....
+[source,clojure]
+----
+;; A test will be generated for this code block
+(apply str (interpose " " ["test" "me" "by" "default"]))
+;; =>  "test me by default"
+----
+....
+
 // Notice the use of CommonMark syntax for section title here, we test that we recognize this syntax
 ## Section Titles
 Test-doc-blocks will try to give each test block some context by including its filename, section title and starting line number.
@@ -324,7 +385,7 @@ And this level 2 type
 ---------------------
 ----
 
-This code block should include "Section Titles" as part of the context for its generated test.
+This code block should include "Section Titles" (the actual title of this section) as part of the context for its generated test.
 
 [source,markdown]
 ....

--- a/doc/example.md
+++ b/doc/example.md
@@ -91,38 +91,40 @@ It is sometimes just nice to know that your code snippet will run without except
 ## Inline Options
 You can, to some limited extent, communicate your intent to test-doc-blocks.
 
-Test-doc-blocks will look for CommonMark comments that begin with `:test-doc-blocks`.
+Test-doc-blocks will look for CommonMark `:test-doc-blocks` comment lines.
 
 It currently understands the following options:
 
-- `:test-doc-blocks/apply` - controls to what code blocks options are applied
 - `:test-doc-blocks/skip` - skips the next code block
 - `:test-doc-blocks/reader-cond` - wraps your code block in a reader conditional
 - `:test-doc-blocks/test-ns` - specifies the output test namespace
 - `:test-doc-blocks/platform` - specifies Clojure file type to generate for test ns
 - `:test-doc-blocks/meta` - attach metadata to generated tests
-
-### Applying Options - :apply
-
-By default, new options are applied to the next Clojure code block only.
-
-You can change this by including the `:test-doc-blocks/apply` option:
-
-- `:next` - default - applies new options to next Clojure code block only
-- `:all-next` - applies new options to all subsequent code blocks in the document until specifically overridden with new opts
+- `:test-doc-blocks/apply` - controls to what code blocks options are applied
 
 ### Skipping Code Blocks - :skip
 
 By default, test-doc-blocks will create tests for all Clojure code blocks it finds in the files you specified.
 
-Tell test-doc-blocks to skip the next Clojure code block via the following CommonMark comment:
+Tell test-doc-blocks to skip the next Clojure code block via `<!-- #:test-doc-blocks {:skip true} -->`:
+
+~~~markdown
+<!-- #:test-doc-blocks {:skip true} -->
+```Clojure
+;; no tests will be generated for this Clojure code block
+
+(something we don't want to test ...
+```
+~~~
+
+Because `:skip` is a boolean, you can use the shorter `<!-- :test-doc-blocks/skip -->`:
 
 ~~~markdown
 <!-- :test-doc-blocks/skip -->
 ```Clojure
 ;; no tests will be generated for this Clojure code block
 
-(something we don't want to test)
+(something we don't want to test ...
 ```
 ~~~
 
@@ -169,7 +171,7 @@ Test-doc-blocks does no special checking, but `:reader-cond` only makes sense fo
 ### Specifying Test Namespace - :test-ns
 
 By default, test-doc-blocks will generate tests to namespaces based on document filenames.
-This file is named `example.md`. Test-doc-blocks, up to this point has been generating tests to the `example-md-test` namespace.
+This file your are reading now is named `example.md`. Test-doc-blocks, up to this point has been generating tests to the `example-md-test` namespace.
 
 If this does not work for you, you can override this default via a CommonMark comment:
 
@@ -217,7 +219,7 @@ When specifying the platform, remember that:
 - For Clojure `my-ns-file.clj` will be picked over `my-ns-file.cljc`
 - For ClojureScript `my-ns-file.cljs` will be picked over `my-ns-file.cljc`
 
-So if you are generating mixed platforms, you might want to specify the test-ns as well.
+So if you are generating mixed platforms, you might want to specify the test-ns as well:
 
 ~~~markdown
 <!-- #:test-doc-blocks{:platform :cljs :test-ns example-md-cljs-test} -->
@@ -274,11 +276,60 @@ user=> (into [] {:a 1})
 ```
 ~~~
 
+### Applying Options - :apply
+
+Use the `:test-doc-blocks/apply` option to control which code blocks your specified option(s) apply to:
+
+- `:next` - default - applies new options to next Clojure code block only
+- `:all-next` - applies new options to all subsequent code blocks in the document until specifically overridden with new opts
+
+For example, maybe you want test-doc-blocks to skip code blocks by default:
+
+~~~markdown
+<!-- #:test-doc-blocks{:skip true :apply :all-next} -->
+~~~
+
+All subsequent code blocks would be skipped.
+
+~~~markdown
+```clojure
+;; I am a code block that is skipped by test-doc-blocks
+(maybe some code that won't compile ...
+```
+~~~
+
+Then you could choose to not skip a code block like so:
+
+~~~markdown
+<!-- #:test-doc-blocks{:skip false} -->
+```clojure
+;; A test will be generated for this code block
+(apply str (interpose " " ["don't" "skip" "me!"]))
+;; =>  "don't skip me!"
+```
+~~~
+
+To have test-doc-blocks stop skipping code blocks by default:
+
+~~~markdown
+<!-- #:test-doc-blocks{:skip false :apply :all-next} -->
+~~~
+
+And now test-doc-blocks will generate tests for subsequent code blocks.
+
+~~~markdown
+```clojure
+;; A test will be generated for this code block
+(apply str (interpose " " ["test" "me" "by" "default"]))
+;; =>  "test me by default"
+```
+~~~
+
 # Section Titles
 
 Test-doc-blocks will try to give each test block some context by including its filename, section title and starting line number.
 
-This code block should include "Section Titles" as part of the context for its generated test.
+This code block should include "Section Titles" (the actual title of this section) as part of the context for its generated test.
 
 ~~~markdown
 ```Clojure

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_cljs_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_cljs_test.cljs
@@ -6,7 +6,7 @@
   (:import goog.events.EventType))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 247 - Specifying The Platform - :platform"
+  (clojure.test/testing  "doc/example.adoc - line 252 - Specifying The Platform - :platform"
 ;; this code block will generate a test under example-adoc-cljs-test ns to a .cljs file
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_inline_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_inline_ns_test.cljc
@@ -10,7 +10,7 @@
   (:import #?@(:clj [java.util.List java.util.Queue java.util.Set] :cljs [goog.math.Long goog.math.Vec2 goog.math.Vec3])))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 411 - Inline requires and imports"
+  (clojure.test/testing  "doc/example.adoc - line 472 - Inline requires and imports"
 ;; Stick the basics for requires, shorthand notation isn't supported
 
 ;; Some examples:

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_inline_refer_clojure_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_inline_refer_clojure_test.cljc
@@ -7,7 +7,7 @@
             [clojure.edn :refer [read-string]]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 442 - Inline refer-clojure"
+  (clojure.test/testing  "doc/example.adoc - line 503 - Inline refer-clojure"
 ;; a contrived example that uses uses clojure.edn/read-string in place
 ;; of clojure.core/read-string and excludes clojure.core/for
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns/ns1_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns/ns1_test.cljc
@@ -6,7 +6,7 @@
             [clojure.string :as string]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 215 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.adoc - line 220 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-adoc-new-ns.ns1-test
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns_test.cljc
@@ -5,7 +5,7 @@
             #?(:clj lread.test-doc-blocks.runtime)))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 199 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.adoc - line 204 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-adoc-new-ns-test
 
 (clojure.test/is (= '8 (* 2 4)))))

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_test.cljc
@@ -48,7 +48,7 @@
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0005
-  (clojure.test/testing  "doc/example.adoc - line 156 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.adoc - line 160 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:clj
 (do
 ;; This code block will be wrapped in a #?(:clj (do ...))
@@ -61,7 +61,7 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0006
-  (clojure.test/testing  "doc/example.adoc - line 168 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.adoc - line 172 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:cljs
 (do
 ;; This code block will be wrapped in a #?(:cljs (do ...))
@@ -73,18 +73,18 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0007
-  (clojure.test/testing  "doc/example.adoc - line 178 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.adoc - line 182 - Wrap Test in a Reader Conditional - :reader-cond"
 ;; And our generic cljc code:
 (clojure.test/is (= '[1 2 3] (read-string "[1 2 3]")))))
 
 (clojure.test/deftest ^:testing-meta123 block-0008
-  (clojure.test/testing  "doc/example.adoc - line 278 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.adoc - line 283 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata {:testing-meta123 true}
 
 (clojure.test/is (= '[[:a 1]] (into [] {:a 1})))))
 
 (clojure.test/deftest ^{:testing-meta123 "a-specific-value", :testing-meta789 :yip} block-0009
-  (clojure.test/testing  "doc/example.adoc - line 291 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.adoc - line 296 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata:
 ;;  {:testing-meta123 "a-specific-value" :testing-meta789 :yip}
 
@@ -95,19 +95,29 @@ nil
    ["oh" "my" "goodness"])))))
 
 (clojure.test/deftest block-0010
-  (clojure.test/testing  "doc/example.adoc - line 331 - Section Titles"
+  (clojure.test/testing  "doc/example.adoc - line 339 - Applying Options - :apply"
+;; A test will be generated for this code block
+(clojure.test/is (= '"don't skip me!" (apply str (interpose " " ["don't" "skip" "me!"]))))))
+
+(clojure.test/deftest block-0011
+  (clojure.test/testing  "doc/example.adoc - line 358 - Applying Options - :apply"
+;; A test will be generated for this code block
+(clojure.test/is (= '"test me by default" (apply str (interpose " " ["test" "me" "by" "default"]))))))
+
+(clojure.test/deftest block-0012
+  (clojure.test/testing  "doc/example.adoc - line 392 - Section Titles"
 nil
 
 (clojure.test/is (= '"well!how!about!that" (string/join "!" ["well" "how" "about" "that"])))))
 
-(clojure.test/deftest block-0011
-  (clojure.test/testing  "doc/example.adoc - line 347 - Support for CommonMark Code Block Syntax"
+(clojure.test/deftest block-0013
+  (clojure.test/testing  "doc/example.adoc - line 408 - Support for CommonMark Code Block Syntax"
 nil
 
 (clojure.test/is (= '{1 :a, 2 :b} (set/map-invert {:a 1 :b 2})))))
 
-(clojure.test/deftest block-0012
-  (clojure.test/testing  "doc/example.adoc - line 378 - Setup Code & env-test-doc-blocks"
+(clojure.test/deftest block-0014
+  (clojure.test/testing  "doc/example.adoc - line 439 - Setup Code & env-test-doc-blocks"
 ;; The code in this block will be run in test-doc-blocks generated tests,
 ;; but the block will not show when viewing the rendered doc
 (def some-setup-thingy 42)
@@ -115,25 +125,25 @@ nil
 ; test-doc-blocks dummy assertion to appease tools that fail on no assertions
 (clojure.test/is (= '"dummy" "dummy"))))
 
-(clojure.test/deftest block-0013
-  (clojure.test/testing  "doc/example.adoc - line 389 - Setup Code & env-test-doc-blocks"
+(clojure.test/deftest block-0015
+  (clojure.test/testing  "doc/example.adoc - line 450 - Setup Code & env-test-doc-blocks"
 (clojure.test/is (= '42 some-setup-thingy))))
 
-(clojure.test/deftest block-0014
-  (clojure.test/testing  "doc/example.adoc - line 478 - Test Run Order"
+(clojure.test/deftest block-0016
+  (clojure.test/testing  "doc/example.adoc - line 539 - Test Run Order"
 (defn fn-block1 [] (+ 1 2 3))
 
 ; test-doc-blocks dummy assertion to appease tools that fail on no assertions
 (clojure.test/is (= '"dummy" "dummy"))))
 
-(clojure.test/deftest block-0015
-  (clojure.test/testing  "doc/example.adoc - line 484 - Test Run Order"
+(clojure.test/deftest block-0017
+  (clojure.test/testing  "doc/example.adoc - line 545 - Test Run Order"
 (def var-block2 (+ 4 5 6))
 
 (clojure.test/is (= '21 (+ (fn-block1) var-block2)))))
 
-(clojure.test/deftest block-0016
-  (clojure.test/testing  "doc/example.adoc - line 493 - Test Run Order"
+(clojure.test/deftest block-0018
+  (clojure.test/testing  "doc/example.adoc - line 554 - Test Run Order"
 (clojure.test/is (= '100 (+ (fn-block1) var-block2 79)))))
 
-(defn test-ns-hook [] (block-0001) (block-0002) (block-0003) (block-0004) (block-0005) (block-0006) (block-0007) (block-0008) (block-0009) (block-0010) (block-0011) (block-0012) (block-0013) (block-0014) (block-0015) (block-0016))
+(defn test-ns-hook [] (block-0001) (block-0002) (block-0003) (block-0004) (block-0005) (block-0006) (block-0007) (block-0008) (block-0009) (block-0010) (block-0011) (block-0012) (block-0013) (block-0014) (block-0015) (block-0016) (block-0017) (block-0018))

--- a/test-resources/expected/test-doc-blocks/test/example_md_cljs_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_md_cljs_test.cljs
@@ -6,7 +6,7 @@
   (:import goog.events.EventType))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 224 - Specifying The Platform - :platform"
+  (clojure.test/testing  "doc/example.md - line 226 - Specifying The Platform - :platform"
 ;; this code block will generate tests under example-md-cljs-test ns to a .cljs file
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_md_inline_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_inline_ns_test.cljc
@@ -10,7 +10,7 @@
   (:import #?@(:clj [java.util.List java.util.Queue java.util.Set] :cljs [goog.math.Long goog.math.Vec2 goog.math.Vec3])))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 332 - Inline requires and imports"
+  (clojure.test/testing  "doc/example.md - line 383 - Inline requires and imports"
 ;; Stick the basics for requires, shorthand notation isn't supported
 
 ;; Some examples:

--- a/test-resources/expected/test-doc-blocks/test/example_md_inline_refer_clojure_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_inline_refer_clojure_test.cljc
@@ -7,7 +7,7 @@
             [clojure.edn :refer [read-string]]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 362 - Inline refer-clojure"
+  (clojure.test/testing  "doc/example.md - line 413 - Inline refer-clojure"
 ;; a contrived example that uses uses clojure.edn/read-string in place
 ;; of clojure.core/read-string and excludes clojure.core/for
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_md_new_ns/ns1_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_new_ns/ns1_test.cljc
@@ -6,7 +6,7 @@
             [clojure.string :as string]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 194 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.md - line 196 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-md-new-ns.ns1-test
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_md_new_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_new_ns_test.cljc
@@ -5,7 +5,7 @@
             #?(:clj lread.test-doc-blocks.runtime)))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 178 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.md - line 180 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-md-new-ns-test
 
 (clojure.test/is (= '8 (* 2 4)))))

--- a/test-resources/expected/test-doc-blocks/test/example_md_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_test.cljc
@@ -47,7 +47,7 @@
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0005
-  (clojure.test/testing  "doc/example.md - line 141 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.md - line 143 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:clj
 (do
 ;; This code block will be wrapped in a #?(:clj (do ...))
@@ -60,7 +60,7 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0006
-  (clojure.test/testing  "doc/example.md - line 151 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.md - line 153 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:cljs
 (do
 ;; This code block will be wrapped in a #?(:cljs (do ...))
@@ -72,18 +72,18 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0007
-  (clojure.test/testing  "doc/example.md - line 159 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.md - line 161 - Wrap Test in a Reader Conditional - :reader-cond"
 ;; And our generic cljc code:
 (clojure.test/is (= '[1 2 3] (read-string "[1 2 3]")))))
 
 (clojure.test/deftest ^:testing-meta123 block-0008
-  (clojure.test/testing  "doc/example.md - line 253 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.md - line 255 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata {:testing-meta123 true}
 
 (clojure.test/is (= '[[:a 1]] (into [] {:a 1})))))
 
 (clojure.test/deftest ^{:testing-meta123 "a-specific-value", :testing-meta789 :yip} block-0009
-  (clojure.test/testing  "doc/example.md - line 264 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.md - line 266 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata:
 ;;  {:testing-meta123 "a-specific-value" :testing-meta789 :yip}
 
@@ -94,18 +94,28 @@ nil
    ["oh" "my" "goodness"])))))
 
 (clojure.test/deftest block-0010
-  (clojure.test/testing  "doc/example.md - line 284 - Section Titles"
+  (clojure.test/testing  "doc/example.md - line 305 - Applying Options - :apply"
+;; A test will be generated for this code block
+(clojure.test/is (= '"don't skip me!" (apply str (interpose " " ["don't" "skip" "me!"]))))))
+
+(clojure.test/deftest block-0011
+  (clojure.test/testing  "doc/example.md - line 321 - Applying Options - :apply"
+;; A test will be generated for this code block
+(clojure.test/is (= '"test me by default" (apply str (interpose " " ["test" "me" "by" "default"]))))))
+
+(clojure.test/deftest block-0012
+  (clojure.test/testing  "doc/example.md - line 335 - Section Titles"
 nil
 
 (clojure.test/is (= '"well!how!about!that" (string/join "!" ["well" "how" "about" "that"])))))
 
-(clojure.test/deftest block-0011
-  (clojure.test/testing  "doc/example.md - line 298 - Indented Blocks"
+(clojure.test/deftest block-0013
+  (clojure.test/testing  "doc/example.md - line 349 - Indented Blocks"
 ;; we handle simple cases a-OK.
 (clojure.test/is (= '6 (+ 1 2 3)))))
 
-(clojure.test/deftest block-0012
-  (clojure.test/testing  "doc/example.md - line 306 - Indented Blocks"
+(clojure.test/deftest block-0014
+  (clojure.test/testing  "doc/example.md - line 357 - Indented Blocks"
 ;; we handle indented wrapped strings just fine
 (def s "my
 goodness
@@ -114,23 +124,23 @@ gracious")
 (let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (println s))]
   (clojure.test/is (= ["my" "goodness" "gracious"] (clojure.string/split-lines actual-out))))))
 
-(clojure.test/deftest block-0013
-  (clojure.test/testing  "doc/example.md - line 397 - Test Run Order"
+(clojure.test/deftest block-0015
+  (clojure.test/testing  "doc/example.md - line 448 - Test Run Order"
 (defn fn-block1 [] (+ 1 2 3))
 
 ; test-doc-blocks dummy assertion to appease tools that fail on no assertions
 (clojure.test/is (= '"dummy" "dummy"))))
 
-(clojure.test/deftest block-0014
-  (clojure.test/testing  "doc/example.md - line 402 - Test Run Order"
+(clojure.test/deftest block-0016
+  (clojure.test/testing  "doc/example.md - line 453 - Test Run Order"
 ;; and we continue in this block
 
 (def var-block2 (+ 4 5 6))
 
 (clojure.test/is (= '21 (+ (fn-block1) var-block2)))))
 
-(clojure.test/deftest block-0015
-  (clojure.test/testing  "doc/example.md - line 412 - Test Run Order"
+(clojure.test/deftest block-0017
+  (clojure.test/testing  "doc/example.md - line 463 - Test Run Order"
 (clojure.test/is (= '100 (+ (fn-block1) var-block2 79)))))
 
-(defn test-ns-hook [] (block-0001) (block-0002) (block-0003) (block-0004) (block-0005) (block-0006) (block-0007) (block-0008) (block-0009) (block-0010) (block-0011) (block-0012) (block-0013) (block-0014) (block-0015))
+(defn test-ns-hook [] (block-0001) (block-0002) (block-0003) (block-0004) (block-0005) (block-0006) (block-0007) (block-0008) (block-0009) (block-0010) (block-0011) (block-0012) (block-0013) (block-0014) (block-0015) (block-0016) (block-0017))


### PR DESCRIPTION
Highlights:
- Move `:apply` after all other opts, as it applies to all other opts.
- Describe long and short forms of `:skip`