### PR TITLE
maint: bump deps

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@ A release with known breaking changes is marked with:
 * Tests can now be generated from a header-less doc
 https://github.com/lread/test-doc-blocks/issues/25[#25]
 (thanks for the feedback https://github.com/genmeblog[@genmeblog]!)
+* Bumped malli (used during test generation only)
 
 == v1.1.19 - 2024-05-02 [[v1.1.19]]
 

--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
         babashka/fs {:mvn/version "0.5.20"}
         clj-kondo/clj-kondo {:mvn/version "2024.03.13"}
         dev.nubank/docopt {:mvn/version "0.6.1-fix7"}
-        metosin/malli {:mvn/version "0.16.0"}
+        metosin/malli {:mvn/version "0.16.1"}
         rewrite-clj/rewrite-clj  {:mvn/version "1.1.47"}}
 
  :aliases {;; we use babashka/neil for project attributes
@@ -23,7 +23,7 @@
            :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
            :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
            :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
-           :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-alpha10"}}}
+           :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-alpha11"}}}
 
            ;; clojure -X support for local examples
            :test-doc-blocks {:ns-default lread.test-doc-blocks}
@@ -84,7 +84,7 @@
            ;;
            ;; Deployment
            ;;
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.1"}}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.3"}}
                    :extra-paths ["src" "build"]
                    :ns-default build}
 


### PR DESCRIPTION
Only lib dep is malli.
All others are ci/test/build.