### PR TITLE
maint: bump deps

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,10 +14,13 @@ A release with known breaking changes is marked with:
 // - optional attribute is not [breaking] or [minor breaking]
 //   (adjust these in ci_relase.clj as you see fit)
 
-== Unreleased
+== [minor breaking] Unreleased
 
-* Bumped deps (used during test generation only)
-** Note that you'll need to bump to at least clojure 1.11 when generating tests
+* Minor breaking
+** You'll need to use at least clojure v1.11 when generating tests
+
+* Other changes
+** Bumped deps (used during test generation only)
 
 == v1.1.20 - 2024-05-06 [[v1.1.20]]
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,10 +11,10 @@ A release with known breaking changes is marked with:
 // which will fail on any of:
 // - unreleased section not found,
 // - unreleased section empty
-// - optional attribute is not [breaking] or [minor breaking]
+// - optional unreleased suffix is not [breaking] or [minor breaking]
 //   (adjust these in ci_relase.clj as you see fit)
 
-== [minor breaking] Unreleased
+== Unreleased [minor breaking]
 
 * Minor breaking
 ** You'll need to use at least clojure v1.11 when generating tests

--- a/bb.edn
+++ b/bb.edn
@@ -4,7 +4,7 @@
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
         dev.nubank/docopt {:mvn/version "0.6.1-fix7"}
         version-clj/version-clj {:mvn/version "2.0.3"}
-        etaoin/etaoin {:mvn/version "1.1.42"}
+        etaoin/etaoin {:mvn/version "1.1.43"}
         io.github.babashka/neil {:git/tag "v0.3.68" :git/sha "78ffab1"}}
  :tasks {;; setup
          :requires ([babashka.fs :as fs]

--- a/deps.edn
+++ b/deps.edn
@@ -2,10 +2,10 @@
 
  :deps {org.clojure/clojure {:mvn/version "1.11.4"}
         org.clojure/tools.reader {:mvn/version "1.5.2"}
-        babashka/fs {:mvn/version "0.5.24"}
+        babashka/fs {:mvn/version "0.5.25"}
         clj-kondo/clj-kondo {:mvn/version "2025.04.07"}
         dev.nubank/docopt {:mvn/version "0.6.1-fix7"}
-        metosin/malli {:mvn/version "0.17.0"}
+        metosin/malli {:mvn/version "0.18.0"}
         rewrite-clj/rewrite-clj  {:mvn/version "1.1.49"}}
 
  :aliases {;; we use babashka/neil for project attributes


### PR DESCRIPTION
Also: Requiring minimum of clojure v1.11 is technically potentially a breaking change, so describe it as minor breaking in changelog.