### PR TITLE
Fix multiline expectations

### DIFF
--- a/.clj-kondo/imports/nubank/matcher-combinators/config.edn
+++ b/.clj-kondo/imports/nubank/matcher-combinators/config.edn
@@ -1,0 +1,4 @@
+{:linters
+ {:unresolved-symbol
+  {:exclude [(cljs.test/is [match? thrown-match?])
+             (clojure.test/is [match? thrown-match?])]}}}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,7 +21,11 @@ A release with known breaking changes is marked with:
 
 * Other changes
 ** Test-doc-blocks now correctly specifies `true` for ClojureScript `include-macros`
+https://github.com/lread/test-doc-blocks/issues/29[#29]
 (thanks for raising https://github.com/NoahTheDuke[@NoahTheDuke]! thanks for fixing https://github.com/mattiuusitalo[@mattiuusitalo]!)
+** Editor-style multiline expectations can be fully commented
+https://github.com/lread/test-doc-blocks/issues/33[#33]
+(thanks https://github.com/mattiuusitalo[@mattiuusitalo]!)
 ** Bumped deps (used during test generation only)
 
 == v1.1.20 - 2024-05-06 [[v1.1.20]]

--- a/deps.edn
+++ b/deps.edn
@@ -62,7 +62,8 @@
            ;;
 
            ;; for kaocha see also tests.edn
-           :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
+           :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
+                                 nubank/matcher-combinators {:mvn/version "3.9.1"}}
                     :extra-paths ["test"]
                     :main-opts ["-m" "kaocha.runner"]}
 

--- a/doc/example.adoc
+++ b/doc/example.adoc
@@ -48,6 +48,25 @@ user=> (+ 1 2 3)
 ;; =clj=> \C
 ;; =cljs=> "C"
 
+;; Multiple lines can be verified with leading semicolons
+(into []
+      '(1 2 3 4))
+
+;; => [1
+;;     2
+;;     3
+;;     4]
+
+;; For backwards compatibility, the leading semicolons aren't required
+(into []
+      '(1 2 3 4))
+
+;; => [1
+       2
+       3
+       4]
+
+
 ;; and verifies, when asked, to check what was written to stdout
 (println "hey there!")
 ;; stdout=> hey there!

--- a/doc/example.adoc
+++ b/doc/example.adoc
@@ -43,29 +43,15 @@ user=> (+ 1 2 3)
 (+ 1 2 3 4)
 ;; => 10
 
+;; the expected value can span multiple lines
+(assoc {} :foo :bar :quu :baz)
+;; => {:foo :bar
+;;     :quu :baz}
+
 ;; it understands that Clojure and ClojureScript can evaluate differently
 \C
 ;; =clj=> \C
 ;; =cljs=> "C"
-
-;; Multiple lines can be verified with leading semicolons
-(into []
-      '(1 2 3 4))
-
-;; => [1
-;;     2
-;;     3
-;;     4]
-
-;; For backwards compatibility, the leading semicolons aren't required
-(into []
-      '(1 2 3 4))
-
-;; => [1
-       2
-       3
-       4]
-
 
 ;; and verifies, when asked, to check what was written to stdout
 (println "hey there!")
@@ -117,6 +103,54 @@ It is sometimes just nice to know that your code snippet will run without except
      (apply str))
 ----
 
+== Multiline Expectations
+
+It is normal for `=stdout=>` and `=stderr=>` output to span multiple lines.
+You can span other expected output over multiple lines for readability.
+
+//#:test-doc-blocks {:platform :clj :test-ns example-adoc-out-test}
+[source,clj]
+----
+;; A snippit of Clojure where we check result, stderr and stdout
+(do
+  (println "Hi ho\nHi ho\nTo out I will go")
+  (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine"))
+  (range 1 16))
+;; => ( 1  2  3  4  5
+;;      6  7  8  9 10
+;;     11 12 13 14 15)
+;; =stdout=> Hi ho
+;; Hi ho
+;; To out I will go
+;; =stderr=>
+;; To err is human
+;; To forgive
+;; Is devine
+----
+
+If your expected output contains subsequent lines starting with test-doc-block `+=*>+` markers, you can distinguish by using a single semicolon prefix for subsequent lines:
+
+//#:test-doc-blocks {:platform :clj :test-ns example-adoc-out-test}
+[source,clj]
+----
+;; A snippit of Clojure where we check result, stderr and stdout
+(do
+  (println "Hi ho\nHi ho\nTo out I will go\n=stderr=> still part of stdout")
+  (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine\n=> part of stderr"))
+  [:bip :bop '=stdout> :bap :borp])
+;; => [:bip :bop
+;      =stdout> :bap
+;      :borp]
+;; =stdout=> Hi ho
+; Hi ho
+; To out I will go
+; =stderr=> still part of stdout
+;; =stderr=>
+; To err is human
+; To forgive
+; Is devine
+; => part of stderr
+----
 
 == Inline Options
 You can, to some limited extent, communicate your intent to test-doc-blocks.

--- a/doc/example.adoc
+++ b/doc/example.adoc
@@ -128,7 +128,7 @@ You can span other expected output over multiple lines for readability.
 ;; Is devine
 ----
 
-If your expected output contains subsequent lines starting with test-doc-block `+=*>+` markers, you can distinguish by using a single semicolon prefix for subsequent lines:
+If your expected stdout or stderr contains subsequent lines starting with test-doc-block `+=*>+` markers, you can distinguish by using a single semicolon prefix for subsequent lines:
 
 //#:test-doc-blocks {:platform :clj :test-ns example-adoc-out-test}
 [source,clj]
@@ -139,8 +139,8 @@ If your expected output contains subsequent lines starting with test-doc-block `
   (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine\n=> part of stderr"))
   [:bip :bop '=stdout> :bap :borp])
 ;; => [:bip :bop
-;      =stdout> :bap
-;      :borp]
+;;     =stdout> :bap
+;;     :borp]
 ;; =stdout=> Hi ho
 ; Hi ho
 ; To out I will go

--- a/doc/example.md
+++ b/doc/example.md
@@ -42,7 +42,7 @@ Within your Clojure code blocks, test-doc-blocks automatically generates asserti
    ;; => {:foo :bar
    ;      :quu :baz}
 
-   ;; Of if you prefer, without the leading comment character
+   ;; Or if you prefer, without the leading comment character
    (assoc {} :foo :bar :quu :baz)
    ;; => {:foo :bar
           :quu :baz}

--- a/doc/example.md
+++ b/doc/example.md
@@ -37,15 +37,10 @@ Within your Clojure code blocks, test-doc-blocks automatically generates asserti
    (+ 1 2 3 4)
    ;; => 10
 
-   ;; Expected output can span multiple lines
+   ;; the expected value can span multiple lines
    (assoc {} :foo :bar :quu :baz)
    ;; => {:foo :bar
-   ;      :quu :baz}
-
-   ;; Or if you prefer, without the leading comment character
-   (assoc {} :foo :bar :quu :baz)
-   ;; => {:foo :bar
-          :quu :baz}
+   ;;     :quu :baz}
 
    ;; it understands that Clojure and ClojureScript can evaluate differently
    \C
@@ -62,7 +57,6 @@ Within your Clojure code blocks, test-doc-blocks automatically generates asserti
    ; is this right?
    ; or not?
    ```
-
    Sometimes we might care about evaluated result, stderr and stdout.
    <!-- #:test-doc-blocks {:platform :clj :test-ns example-md-out-test} -->
    ```clj
@@ -75,7 +69,6 @@ Within your Clojure code blocks, test-doc-blocks automatically generates asserti
    ;; =stderr=> To err is human
    ;; =stdout=> To out I go
    ```
-
    <!-- #:test-doc-blocks {:platform :cljs :test-ns example-md-out-test} -->
    ```cljs
    ;; And the same idea for ClojureScript
@@ -96,6 +89,51 @@ It is sometimes just nice to know that your code snippet will run without except
      reverse
      reverse
      (apply str))
+```
+## Multiline Expectations
+
+It is normal for `=stdout=>` and `=stderr=>` output to span multiple lines.
+You can span other expected output over multiple lines for readability.
+
+<!-- #:test-doc-blocks {:platform :clj :test-ns example-md-out-test} -->
+```clj
+;; A snippit of Clojure where we check result, stderr and stdout
+(do
+  (println "Hi ho\nHi ho\nTo out I will go")
+  (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine"))
+  (range 1 16))
+;; => ( 1  2  3  4  5
+;;      6  7  8  9 10
+;;     11 12 13 14 15) 
+;; =stdout=> Hi ho
+;; Hi ho
+;; To out I will go
+;; =stderr=> 
+;; To err is human
+;; To forgive
+;; Is devine
+```
+If your expected output contains subsequent lines starting with test-doc-block `+=*>+` markers, you can distinguish by using a single semicolon prefix for subsequent lines:
+
+<!-- #:test-doc-blocks {:platform :clj :test-ns example-md-out-test} -->
+```clj
+;; A snippit of Clojure where we check result, stderr and stdout
+(do
+  (println "Hi ho\nHi ho\nTo out I will go\n=stderr=> still part of stdout")
+  (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine\n=> part of stderr"))
+  [:bip :bop '=stdout> :bap :borp])
+;; => [:bip :bop
+;      =stdout> :bap
+;      :borp]
+;; =stdout=> Hi ho
+; Hi ho
+; To out I will go
+; =stderr=> still part of stdout
+;; =stderr=> 
+; To err is human
+; To forgive
+; Is devine
+; => part of stderr
 ```
 
 ## Inline Options

--- a/doc/example.md
+++ b/doc/example.md
@@ -37,6 +37,16 @@ Within your Clojure code blocks, test-doc-blocks automatically generates asserti
    (+ 1 2 3 4)
    ;; => 10
 
+   ;; Expected output can span multiple lines
+   (assoc {} :foo :bar :quu :baz)
+   ;; => {:foo :bar
+   ;      :quu :baz}
+
+   ;; Of if you prefer, without the leading comment character
+   (assoc {} :foo :bar :quu :baz)
+   ;; => {:foo :bar
+          :quu :baz}
+
    ;; it understands that Clojure and ClojureScript can evaluate differently
    \C
    ;; =clj=> \C

--- a/doc/example.md
+++ b/doc/example.md
@@ -113,7 +113,7 @@ You can span other expected output over multiple lines for readability.
 ;; To forgive
 ;; Is devine
 ```
-If your expected output contains subsequent lines starting with test-doc-block `+=*>+` markers, you can distinguish by using a single semicolon prefix for subsequent lines:
+If your expected stdout or stderr contains subsequent lines starting with test-doc-block `+=*>+` markers, you can distinguish by using a single semicolon prefix for subsequent lines:
 
 <!-- #:test-doc-blocks {:platform :clj :test-ns example-md-out-test} -->
 ```clj
@@ -123,8 +123,8 @@ If your expected output contains subsequent lines starting with test-doc-block `
   (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine\n=> part of stderr"))
   [:bip :bop '=stdout> :bap :borp])
 ;; => [:bip :bop
-;      =stdout> :bap
-;      :borp]
+;;     =stdout> :bap
+;;     :borp]
 ;; =stdout=> Hi ho
 ; Hi ho
 ; To out I will go

--- a/src/lread/test_doc_blocks/impl/body_prep.clj
+++ b/src/lread/test_doc_blocks/impl/body_prep.clj
@@ -1,6 +1,14 @@
 (ns ^:no-doc lread.test-doc-blocks.impl.body-prep
   "Prep a doc block to be converted into a test."
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [rewrite-clj.zip :as z]))
+
+(defn- parseable? [s]
+  (try
+    (let [zloc (z/of-string s)]
+      (not= :forms (z/tag zloc)))
+    (catch Exception _ex
+      false)))
 
 (defn ^:no-doc prep-block-for-conversion-to-test
   "Convert doc block to Clojure that can be more easily parsed.
@@ -29,77 +37,128 @@
   "
   [block-text]
   (let [re-editor-style-out-expected #"^\s*(?:;;\s*){0,1}(=stdout=>|=stderr=>)(?:\s*$| {0,1}(.*))"
-        re-out-continue #"^\s*;+(?:\s*$| {0,1}(.*))"
-        re-editor-style-expected #"^\s*(?:;;\s*){0,1}(=clj=>|=cljs=>|=>)\s*(.*$)"]
-    (-> (loop [acc {:body ""}
+        re-line-continue             #"^\s*;+(?:\s*$| {0,1}(.*))"
+        re-editor-style-expected     #"^\s*(?:;;\s*){0,1}(=clj=>|=cljs=>|=>)\s*(.*$)"]
+    (-> (loop [{:keys [body parsing assert-token expectation eo-assert?] :as state} {:body ""}
                [line :as lines] (string/split-lines block-text)]
           (let [line (and line (string/trimr line))
-                [_ assert-token payload] (when line
-                                           (or (re-matches re-editor-style-expected line)
-                                               (re-matches re-editor-style-out-expected line)))]
+                [_ line-assert-token line-payload] (when line
+                                                     (or (re-matches re-editor-style-expected line)
+                                                         (re-matches re-editor-style-out-expected line)))]
             (cond
-              ;; expectation ends
-              (and (:out acc) (or (not line)
-                                  assert-token
-                                  (not (re-matches re-out-continue line))
-                                  (re-matches re-editor-style-expected line)))
-              (recur (as-> acc acc
-                       (case (:style acc)
-                         :out
-                         (update acc :body str (str (:out-token acc) " "
-                                                    (conj (:out acc)) "\n"))
-                         :editor
-                         (update acc :body str (str (:assert-token acc) " "
-                                                    (string/join "\n" (:out acc))
-                                                    "\n")))
-                       (dissoc acc :out :out-token :assert-token :style))
-                     lines)
+              (= :eval-expectation parsing)
+              (cond
+                ;; end of eval expectation?
+                (or (not line) eo-assert?)
+                (recur {:body (str body
+                                   assert-token " "
+                                   (string/join "\n" expectation)
+                                   "\n")}
+                       lines)
+
+                :else
+                (let [[_ line-continue] (re-matches re-line-continue line)
+                      eval-line (or line-continue line)]
+                  (recur (let [{:keys [expectation] :as state} (update state :expectation conj (or eval-line ""))]
+                           (if (parseable? (string/join "\n" expectation))
+                             (assoc state :eo-assert? true)
+                             state))
+                         (rest lines))))
+
+              (= :out-expectation parsing)
+              (cond
+                ;; end of expecation?
+                (or (not line)
+                    line-assert-token
+                    eo-assert?
+                    (not (re-matches re-line-continue line)))
+                (recur {:body (str body
+                                   assert-token " "
+                                   (conj expectation)
+                                   "\n")}
+                       lines)
+
+                (re-matches re-line-continue line)
+                (let [[_ line-continue] (re-matches re-line-continue line)]
+                  (recur (update state :expectation conj (or line-continue ""))
+                         (rest lines)))
+
+                :else
+                (recur (assoc state :eo-assert? true) lines))
 
               ;; all done?
               (not line)
-              acc
+              state
 
-              ;; collecting expectation
-              (and (:out acc)
-                   (not assert-token)
-                   (re-matches re-out-continue line))
-              (let [[_ out-line] (re-matches re-out-continue line)]
-                (recur (update acc :out conj (or out-line ""))
-                       (rest lines)))
-
-              ;; out expectation starts
-              (or (= "=stdout=>" assert-token)
-                  (= "=stderr=>" assert-token))
-              (recur (assoc acc
-                            :style :out
-                            :out (if payload [payload] [])
-                            :out-token assert-token)
+              ;; start of out expection
+              (or (= "=stdout=>" line-assert-token)
+                  (= "=stderr=>" line-assert-token))
+              (recur (assoc state
+                            :parsing :out-expectation
+                            :expectation (if line-payload [line-payload] [])
+                            :assert-token line-assert-token)
                      (rest lines))
 
-              ;; editor style evaluation expectation:
-              ;; actual
-              ;; ;;=> expected
-              assert-token
-              (recur (assoc acc
-                            :out (if payload [payload] [])
-                            :style :editor
-                            :assert-token assert-token)
+              ;; editor style expectation
+              line-assert-token
+              (recur (let [{:keys [expectation] :as state} (assoc state
+                                                                  :parsing :eval-expectation
+                                                                  :expectation (if line-payload [line-payload] [])
+                                                                  :assert-token line-assert-token)]
+                       (if (parseable? (string/join "\n" expectation))
+                         (assoc state :eo-assert? true)
+                         state))
                      (rest lines))
 
-              ;; other lines
               :else
-              (recur (update acc :body str (str line "\n"))
+              (recur (update state :body str (str line "\n"))
                      (rest lines)))))
         :body)))
 
 
 (comment
+  (parseable? " , ")
+
   (prep-block-for-conversion-to-test ";; =stdout=> line1
 ; line2")
+  ;; => "=stdout=> [\"line1\" \"line2\"]\n"
 
   (prep-block-for-conversion-to-test
    "(assoc {} :foo :bar :baz :kikka)
 ;; => {:foo :bar
 ;  :baz :kikka}"
    )
-  )
+  ;; => "(assoc {} :foo :bar :baz :kikka)\n=> {:foo :bar\n :baz :kikka}\n"
+
+  (prep-block-for-conversion-to-test
+   "(assoc {} :foo :bar :baz :kikka)
+;; => ^{:foo :bar
+;;     :baz :kikka} []
+;; some other comment
+;; more comments
+;; =stdout=> foo
+"
+)
+  ;; => "(assoc {} :foo :bar :baz :kikka)\n=> ^{:foo :bar\n    :baz :kikka} []\n;; some other comment\n;; more comments\n=stdout=> [\"foo\"]\n"
+
+
+  (parseable? "   ")
+  ;; => false
+  (parseable? "   32 ")
+  ;; => true
+
+  ;; only :a will be significant
+  (parseable? ":a 2 3")
+  ;; => true
+
+  (parseable? "[:a 2\n;;some foo\n 3]")
+  ;; => true
+
+  (parseable? ";; foo")
+  ;; => false
+
+  ;; for now don't skip discards, user should get error for this eventualy
+  (parseable? "#_ 3")
+  ;; => true
+
+  :eoc)

--- a/src/lread/test_doc_blocks/impl/body_prep.clj
+++ b/src/lread/test_doc_blocks/impl/body_prep.clj
@@ -29,7 +29,7 @@
   "
   [block-text]
   (let [re-editor-style-out-expected #"^\s*(?:;;\s*){0,1}(=stdout=>|=stderr=>)(?:\s*$| {0,1}(.*))"
-        re-out-continue #"^\s*;(?:\s*$| {0,1}(.*))"
+        re-out-continue #"^\s*;+(?:\s*$| {0,1}(.*))"
         re-editor-style-expected #"^\s*(?:;;\s*){0,1}(=clj=>|=cljs=>|=>)\s*(.*$)"]
     (-> (loop [acc {:body ""}
                [line :as lines] (string/split-lines block-text)]

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_cljs_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_cljs_test.cljs
@@ -6,7 +6,7 @@
   (:import goog.events.EventType))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 271 - Specifying The Platform - :platform"
+  (clojure.test/testing  "doc/example.adoc - line 305 - Specifying The Platform - :platform"
 ;; this code block will generate a test under example-adoc-cljs-test ns to a .cljs file
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_cljs_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_cljs_test.cljs
@@ -6,7 +6,7 @@
   (:import goog.events.EventType))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 252 - Specifying The Platform - :platform"
+  (clojure.test/testing  "doc/example.adoc - line 271 - Specifying The Platform - :platform"
 ;; this code block will generate a test under example-adoc-cljs-test ns to a .cljs file
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_inline_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_inline_ns_test.cljc
@@ -10,7 +10,7 @@
   (:import #?@(:clj [java.util.List java.util.Queue java.util.Set] :cljs [goog.math.Long goog.math.Vec2 goog.math.Vec3])))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 472 - Inline requires and imports"
+  (clojure.test/testing  "doc/example.adoc - line 491 - Inline requires and imports"
 ;; Stick the basics for requires, shorthand notation isn't supported
 
 ;; Some examples:

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_inline_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_inline_ns_test.cljc
@@ -10,7 +10,7 @@
   (:import #?@(:clj [java.util.List java.util.Queue java.util.Set] :cljs [goog.math.Long goog.math.Vec2 goog.math.Vec3])))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 491 - Inline requires and imports"
+  (clojure.test/testing  "doc/example.adoc - line 525 - Inline requires and imports"
 ;; Stick the basics for requires, shorthand notation isn't supported
 
 ;; Some examples:

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_inline_refer_clojure_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_inline_refer_clojure_test.cljc
@@ -7,7 +7,7 @@
             [clojure.edn :refer [read-string]]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 522 - Inline refer-clojure"
+  (clojure.test/testing  "doc/example.adoc - line 556 - Inline refer-clojure"
 ;; a contrived example that uses uses clojure.edn/read-string in place
 ;; of clojure.core/read-string and excludes clojure.core/for
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_inline_refer_clojure_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_inline_refer_clojure_test.cljc
@@ -7,7 +7,7 @@
             [clojure.edn :refer [read-string]]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 503 - Inline refer-clojure"
+  (clojure.test/testing  "doc/example.adoc - line 522 - Inline refer-clojure"
 ;; a contrived example that uses uses clojure.edn/read-string in place
 ;; of clojure.core/read-string and excludes clojure.core/for
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns/ns1_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns/ns1_test.cljc
@@ -6,7 +6,7 @@
             [clojure.string :as string]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 220 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.adoc - line 239 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-adoc-new-ns.ns1-test
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns/ns1_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns/ns1_test.cljc
@@ -6,7 +6,7 @@
             [clojure.string :as string]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 239 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.adoc - line 273 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-adoc-new-ns.ns1-test
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns_test.cljc
@@ -5,7 +5,7 @@
             #?(:clj lread.test-doc-blocks.runtime)))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 204 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.adoc - line 223 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-adoc-new-ns-test
 
 (clojure.test/is (= '8 (* 2 4)))))

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_new_ns_test.cljc
@@ -5,7 +5,7 @@
             #?(:clj lread.test-doc-blocks.runtime)))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 223 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.adoc - line 257 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-adoc-new-ns-test
 
 (clojure.test/is (= '8 (* 2 4)))))

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.clj
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.clj
@@ -4,7 +4,7 @@
             lread.test-doc-blocks.runtime))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 66 - The Basics"
+  (clojure.test/testing  "doc/example.adoc - line 85 - The Basics"
 ;; A snippit of Clojure where we check result, stderr and stdout
 (let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
   (println "To out I go")

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.clj
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.clj
@@ -35,8 +35,8 @@
   (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine\n=> part of stderr"))
   [:bip :bop '=stdout> :bap :borp]))]
   (clojure.test/is (= '[:bip :bop
-     =stdout> :bap
-     :borp] actual))
+    =stdout> :bap
+    :borp] actual))
   (clojure.test/is (= ["To err is human" "To forgive" "Is devine" "=> part of stderr"] (clojure.string/split-lines actual-err)))
   (clojure.test/is (= ["Hi ho" "Hi ho" "To out I will go" "=stderr=> still part of stdout"] (clojure.string/split-lines actual-out))))))
 

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.clj
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.clj
@@ -4,7 +4,7 @@
             lread.test-doc-blocks.runtime))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 85 - The Basics"
+  (clojure.test/testing  "doc/example.adoc - line 71 - The Basics"
 ;; A snippit of Clojure where we check result, stderr and stdout
 (let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
   (println "To out I go")
@@ -14,4 +14,30 @@
   (clojure.test/is (= ["To err is human"] (clojure.string/split-lines actual-err)))
   (clojure.test/is (= ["To out I go"] (clojure.string/split-lines actual-out))))))
 
-(defn test-ns-hook [] (block-0001))
+(clojure.test/deftest block-0002
+  (clojure.test/testing  "doc/example.adoc - line 113 - Multiline Expectations"
+;; A snippit of Clojure where we check result, stderr and stdout
+(let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
+  (println "Hi ho\nHi ho\nTo out I will go")
+  (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine"))
+  (range 1 16)))]
+  (clojure.test/is (= '( 1  2  3  4  5
+     6  7  8  9 10
+    11 12 13 14 15) actual))
+  (clojure.test/is (= ["To err is human" "To forgive" "Is devine"] (clojure.string/split-lines actual-err)))
+  (clojure.test/is (= ["Hi ho" "Hi ho" "To out I will go"] (clojure.string/split-lines actual-out))))))
+
+(clojure.test/deftest block-0003
+  (clojure.test/testing  "doc/example.adoc - line 135 - Multiline Expectations"
+;; A snippit of Clojure where we check result, stderr and stdout
+(let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
+  (println "Hi ho\nHi ho\nTo out I will go\n=stderr=> still part of stdout")
+  (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine\n=> part of stderr"))
+  [:bip :bop '=stdout> :bap :borp]))]
+  (clojure.test/is (= '[:bip :bop
+     =stdout> :bap
+     :borp] actual))
+  (clojure.test/is (= ["To err is human" "To forgive" "Is devine" "=> part of stderr"] (clojure.string/split-lines actual-err)))
+  (clojure.test/is (= ["Hi ho" "Hi ho" "To out I will go" "=stderr=> still part of stdout"] (clojure.string/split-lines actual-out))))))
+
+(defn test-ns-hook [] (block-0001) (block-0002) (block-0003))

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.cljs
@@ -4,7 +4,7 @@
             [lread.test-doc-blocks.runtime :include-macros true]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 98 - The Basics"
+  (clojure.test/testing  "doc/example.adoc - line 84 - The Basics"
 ;; And the same idea for ClojureScript
 (let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
   (println "To out I go")

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_out_test.cljs
@@ -4,7 +4,7 @@
             [lread.test-doc-blocks.runtime :include-macros true]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.adoc - line 79 - The Basics"
+  (clojure.test/testing  "doc/example.adoc - line 98 - The Basics"
 ;; And the same idea for ClojureScript
 (let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
   (println "To out I go")

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_test.cljc
@@ -29,6 +29,18 @@
 ;; it understands that Clojure and ClojureScript can evaluate differently
 #?(:clj (clojure.test/is (= '\C \C)))
 #?(:cljs (clojure.test/is (= '"C" \C)))
+;; Multiple lines can be verified with leading semicolons
+(clojure.test/is (= '[1
+    2
+    3
+    4] (into []
+      '(1 2 3 4))))
+;; For backwards compatibility, the leading semicolons aren't required
+(clojure.test/is (= '[1
+       2
+       3
+       4] (into []
+      '(1 2 3 4))))
 ;; and verifies, when asked, to check what was written to stdout
 (println "hey there!")
 ;; stdout=> hey there!
@@ -38,7 +50,7 @@
   (clojure.test/is (= ["is this right?" "or not?"] (clojure.string/split-lines actual-out))))))
 
 (clojure.test/deftest block-0004
-  (clojure.test/testing  "doc/example.adoc - line 94 - The Basics"
+  (clojure.test/testing  "doc/example.adoc - line 113 - The Basics"
 (->> "here we are only checking that our code will run"
      reverse
      reverse
@@ -48,7 +60,7 @@
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0005
-  (clojure.test/testing  "doc/example.adoc - line 160 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.adoc - line 179 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:clj
 (do
 ;; This code block will be wrapped in a #?(:clj (do ...))
@@ -61,7 +73,7 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0006
-  (clojure.test/testing  "doc/example.adoc - line 172 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.adoc - line 191 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:cljs
 (do
 ;; This code block will be wrapped in a #?(:cljs (do ...))
@@ -73,18 +85,18 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0007
-  (clojure.test/testing  "doc/example.adoc - line 182 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.adoc - line 201 - Wrap Test in a Reader Conditional - :reader-cond"
 ;; And our generic cljc code:
 (clojure.test/is (= '[1 2 3] (read-string "[1 2 3]")))))
 
 (clojure.test/deftest ^:testing-meta123 block-0008
-  (clojure.test/testing  "doc/example.adoc - line 283 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.adoc - line 302 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata {:testing-meta123 true}
 
 (clojure.test/is (= '[[:a 1]] (into [] {:a 1})))))
 
 (clojure.test/deftest ^{:testing-meta123 "a-specific-value", :testing-meta789 :yip} block-0009
-  (clojure.test/testing  "doc/example.adoc - line 296 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.adoc - line 315 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata:
 ;;  {:testing-meta123 "a-specific-value" :testing-meta789 :yip}
 
@@ -95,29 +107,29 @@ nil
    ["oh" "my" "goodness"])))))
 
 (clojure.test/deftest block-0010
-  (clojure.test/testing  "doc/example.adoc - line 339 - Applying Options - :apply"
+  (clojure.test/testing  "doc/example.adoc - line 358 - Applying Options - :apply"
 ;; A test will be generated for this code block
 (clojure.test/is (= '"don't skip me!" (apply str (interpose " " ["don't" "skip" "me!"]))))))
 
 (clojure.test/deftest block-0011
-  (clojure.test/testing  "doc/example.adoc - line 358 - Applying Options - :apply"
+  (clojure.test/testing  "doc/example.adoc - line 377 - Applying Options - :apply"
 ;; A test will be generated for this code block
 (clojure.test/is (= '"test me by default" (apply str (interpose " " ["test" "me" "by" "default"]))))))
 
 (clojure.test/deftest block-0012
-  (clojure.test/testing  "doc/example.adoc - line 392 - Section Titles"
+  (clojure.test/testing  "doc/example.adoc - line 411 - Section Titles"
 nil
 
 (clojure.test/is (= '"well!how!about!that" (string/join "!" ["well" "how" "about" "that"])))))
 
 (clojure.test/deftest block-0013
-  (clojure.test/testing  "doc/example.adoc - line 408 - Support for CommonMark Code Block Syntax"
+  (clojure.test/testing  "doc/example.adoc - line 427 - Support for CommonMark Code Block Syntax"
 nil
 
 (clojure.test/is (= '{1 :a, 2 :b} (set/map-invert {:a 1 :b 2})))))
 
 (clojure.test/deftest block-0014
-  (clojure.test/testing  "doc/example.adoc - line 439 - Setup Code & env-test-doc-blocks"
+  (clojure.test/testing  "doc/example.adoc - line 458 - Setup Code & env-test-doc-blocks"
 ;; The code in this block will be run in test-doc-blocks generated tests,
 ;; but the block will not show when viewing the rendered doc
 (def some-setup-thingy 42)
@@ -126,24 +138,24 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0015
-  (clojure.test/testing  "doc/example.adoc - line 450 - Setup Code & env-test-doc-blocks"
+  (clojure.test/testing  "doc/example.adoc - line 469 - Setup Code & env-test-doc-blocks"
 (clojure.test/is (= '42 some-setup-thingy))))
 
 (clojure.test/deftest block-0016
-  (clojure.test/testing  "doc/example.adoc - line 539 - Test Run Order"
+  (clojure.test/testing  "doc/example.adoc - line 558 - Test Run Order"
 (defn fn-block1 [] (+ 1 2 3))
 
 ; test-doc-blocks dummy assertion to appease tools that fail on no assertions
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0017
-  (clojure.test/testing  "doc/example.adoc - line 545 - Test Run Order"
+  (clojure.test/testing  "doc/example.adoc - line 564 - Test Run Order"
 (def var-block2 (+ 4 5 6))
 
 (clojure.test/is (= '21 (+ (fn-block1) var-block2)))))
 
 (clojure.test/deftest block-0018
-  (clojure.test/testing  "doc/example.adoc - line 554 - Test Run Order"
+  (clojure.test/testing  "doc/example.adoc - line 573 - Test Run Order"
 (clojure.test/is (= '100 (+ (fn-block1) var-block2 79)))))
 
 (defn test-ns-hook [] (block-0001) (block-0002) (block-0003) (block-0004) (block-0005) (block-0006) (block-0007) (block-0008) (block-0009) (block-0010) (block-0011) (block-0012) (block-0013) (block-0014) (block-0015) (block-0016) (block-0017) (block-0018))

--- a/test-resources/expected/test-doc-blocks/test/example_adoc_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_adoc_test.cljc
@@ -26,21 +26,12 @@
 ;; test-doc-blocks will generate an assertion to verify (+ 1 2 3 4) evaluates
 ;; to the expected 10
 (clojure.test/is (= '10 (+ 1 2 3 4)))
+;; the expected value can span multiple lines
+(clojure.test/is (= '{:foo :bar
+    :quu :baz} (assoc {} :foo :bar :quu :baz)))
 ;; it understands that Clojure and ClojureScript can evaluate differently
 #?(:clj (clojure.test/is (= '\C \C)))
 #?(:cljs (clojure.test/is (= '"C" \C)))
-;; Multiple lines can be verified with leading semicolons
-(clojure.test/is (= '[1
-    2
-    3
-    4] (into []
-      '(1 2 3 4))))
-;; For backwards compatibility, the leading semicolons aren't required
-(clojure.test/is (= '[1
-       2
-       3
-       4] (into []
-      '(1 2 3 4))))
 ;; and verifies, when asked, to check what was written to stdout
 (println "hey there!")
 ;; stdout=> hey there!
@@ -50,7 +41,7 @@
   (clojure.test/is (= ["is this right?" "or not?"] (clojure.string/split-lines actual-out))))))
 
 (clojure.test/deftest block-0004
-  (clojure.test/testing  "doc/example.adoc - line 113 - The Basics"
+  (clojure.test/testing  "doc/example.adoc - line 99 - The Basics"
 (->> "here we are only checking that our code will run"
      reverse
      reverse
@@ -60,7 +51,7 @@
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0005
-  (clojure.test/testing  "doc/example.adoc - line 179 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.adoc - line 213 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:clj
 (do
 ;; This code block will be wrapped in a #?(:clj (do ...))
@@ -73,7 +64,7 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0006
-  (clojure.test/testing  "doc/example.adoc - line 191 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.adoc - line 225 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:cljs
 (do
 ;; This code block will be wrapped in a #?(:cljs (do ...))
@@ -85,18 +76,18 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0007
-  (clojure.test/testing  "doc/example.adoc - line 201 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.adoc - line 235 - Wrap Test in a Reader Conditional - :reader-cond"
 ;; And our generic cljc code:
 (clojure.test/is (= '[1 2 3] (read-string "[1 2 3]")))))
 
 (clojure.test/deftest ^:testing-meta123 block-0008
-  (clojure.test/testing  "doc/example.adoc - line 302 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.adoc - line 336 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata {:testing-meta123 true}
 
 (clojure.test/is (= '[[:a 1]] (into [] {:a 1})))))
 
 (clojure.test/deftest ^{:testing-meta123 "a-specific-value", :testing-meta789 :yip} block-0009
-  (clojure.test/testing  "doc/example.adoc - line 315 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.adoc - line 349 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata:
 ;;  {:testing-meta123 "a-specific-value" :testing-meta789 :yip}
 
@@ -107,29 +98,29 @@ nil
    ["oh" "my" "goodness"])))))
 
 (clojure.test/deftest block-0010
-  (clojure.test/testing  "doc/example.adoc - line 358 - Applying Options - :apply"
+  (clojure.test/testing  "doc/example.adoc - line 392 - Applying Options - :apply"
 ;; A test will be generated for this code block
 (clojure.test/is (= '"don't skip me!" (apply str (interpose " " ["don't" "skip" "me!"]))))))
 
 (clojure.test/deftest block-0011
-  (clojure.test/testing  "doc/example.adoc - line 377 - Applying Options - :apply"
+  (clojure.test/testing  "doc/example.adoc - line 411 - Applying Options - :apply"
 ;; A test will be generated for this code block
 (clojure.test/is (= '"test me by default" (apply str (interpose " " ["test" "me" "by" "default"]))))))
 
 (clojure.test/deftest block-0012
-  (clojure.test/testing  "doc/example.adoc - line 411 - Section Titles"
+  (clojure.test/testing  "doc/example.adoc - line 445 - Section Titles"
 nil
 
 (clojure.test/is (= '"well!how!about!that" (string/join "!" ["well" "how" "about" "that"])))))
 
 (clojure.test/deftest block-0013
-  (clojure.test/testing  "doc/example.adoc - line 427 - Support for CommonMark Code Block Syntax"
+  (clojure.test/testing  "doc/example.adoc - line 461 - Support for CommonMark Code Block Syntax"
 nil
 
 (clojure.test/is (= '{1 :a, 2 :b} (set/map-invert {:a 1 :b 2})))))
 
 (clojure.test/deftest block-0014
-  (clojure.test/testing  "doc/example.adoc - line 458 - Setup Code & env-test-doc-blocks"
+  (clojure.test/testing  "doc/example.adoc - line 492 - Setup Code & env-test-doc-blocks"
 ;; The code in this block will be run in test-doc-blocks generated tests,
 ;; but the block will not show when viewing the rendered doc
 (def some-setup-thingy 42)
@@ -138,24 +129,24 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0015
-  (clojure.test/testing  "doc/example.adoc - line 469 - Setup Code & env-test-doc-blocks"
+  (clojure.test/testing  "doc/example.adoc - line 503 - Setup Code & env-test-doc-blocks"
 (clojure.test/is (= '42 some-setup-thingy))))
 
 (clojure.test/deftest block-0016
-  (clojure.test/testing  "doc/example.adoc - line 558 - Test Run Order"
+  (clojure.test/testing  "doc/example.adoc - line 592 - Test Run Order"
 (defn fn-block1 [] (+ 1 2 3))
 
 ; test-doc-blocks dummy assertion to appease tools that fail on no assertions
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0017
-  (clojure.test/testing  "doc/example.adoc - line 564 - Test Run Order"
+  (clojure.test/testing  "doc/example.adoc - line 598 - Test Run Order"
 (def var-block2 (+ 4 5 6))
 
 (clojure.test/is (= '21 (+ (fn-block1) var-block2)))))
 
 (clojure.test/deftest block-0018
-  (clojure.test/testing  "doc/example.adoc - line 573 - Test Run Order"
+  (clojure.test/testing  "doc/example.adoc - line 607 - Test Run Order"
 (clojure.test/is (= '100 (+ (fn-block1) var-block2 79)))))
 
 (defn test-ns-hook [] (block-0001) (block-0002) (block-0003) (block-0004) (block-0005) (block-0006) (block-0007) (block-0008) (block-0009) (block-0010) (block-0011) (block-0012) (block-0013) (block-0014) (block-0015) (block-0016) (block-0017) (block-0018))

--- a/test-resources/expected/test-doc-blocks/test/example_md_cljs_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_md_cljs_test.cljs
@@ -6,7 +6,7 @@
   (:import goog.events.EventType))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 226 - Specifying The Platform - :platform"
+  (clojure.test/testing  "doc/example.md - line 236 - Specifying The Platform - :platform"
 ;; this code block will generate tests under example-md-cljs-test ns to a .cljs file
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_md_cljs_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_md_cljs_test.cljs
@@ -6,7 +6,7 @@
   (:import goog.events.EventType))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 236 - Specifying The Platform - :platform"
+  (clojure.test/testing  "doc/example.md - line 274 - Specifying The Platform - :platform"
 ;; this code block will generate tests under example-md-cljs-test ns to a .cljs file
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_md_inline_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_inline_ns_test.cljc
@@ -10,7 +10,7 @@
   (:import #?@(:clj [java.util.List java.util.Queue java.util.Set] :cljs [goog.math.Long goog.math.Vec2 goog.math.Vec3])))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 383 - Inline requires and imports"
+  (clojure.test/testing  "doc/example.md - line 393 - Inline requires and imports"
 ;; Stick the basics for requires, shorthand notation isn't supported
 
 ;; Some examples:

--- a/test-resources/expected/test-doc-blocks/test/example_md_inline_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_inline_ns_test.cljc
@@ -10,7 +10,7 @@
   (:import #?@(:clj [java.util.List java.util.Queue java.util.Set] :cljs [goog.math.Long goog.math.Vec2 goog.math.Vec3])))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 393 - Inline requires and imports"
+  (clojure.test/testing  "doc/example.md - line 431 - Inline requires and imports"
 ;; Stick the basics for requires, shorthand notation isn't supported
 
 ;; Some examples:

--- a/test-resources/expected/test-doc-blocks/test/example_md_inline_refer_clojure_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_inline_refer_clojure_test.cljc
@@ -7,7 +7,7 @@
             [clojure.edn :refer [read-string]]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 413 - Inline refer-clojure"
+  (clojure.test/testing  "doc/example.md - line 423 - Inline refer-clojure"
 ;; a contrived example that uses uses clojure.edn/read-string in place
 ;; of clojure.core/read-string and excludes clojure.core/for
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_md_inline_refer_clojure_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_inline_refer_clojure_test.cljc
@@ -7,7 +7,7 @@
             [clojure.edn :refer [read-string]]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 423 - Inline refer-clojure"
+  (clojure.test/testing  "doc/example.md - line 461 - Inline refer-clojure"
 ;; a contrived example that uses uses clojure.edn/read-string in place
 ;; of clojure.core/read-string and excludes clojure.core/for
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_md_new_ns/ns1_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_new_ns/ns1_test.cljc
@@ -6,7 +6,7 @@
             [clojure.string :as string]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 196 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.md - line 206 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-md-new-ns.ns1-test
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_md_new_ns/ns1_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_new_ns/ns1_test.cljc
@@ -6,7 +6,7 @@
             [clojure.string :as string]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 206 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.md - line 244 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-md-new-ns.ns1-test
 
 nil

--- a/test-resources/expected/test-doc-blocks/test/example_md_new_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_new_ns_test.cljc
@@ -5,7 +5,7 @@
             #?(:clj lread.test-doc-blocks.runtime)))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 190 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.md - line 228 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-md-new-ns-test
 
 (clojure.test/is (= '8 (* 2 4)))))

--- a/test-resources/expected/test-doc-blocks/test/example_md_new_ns_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_new_ns_test.cljc
@@ -5,7 +5,7 @@
             #?(:clj lread.test-doc-blocks.runtime)))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 180 - Specifying Test Namespace - :test-ns"
+  (clojure.test/testing  "doc/example.md - line 190 - Specifying Test Namespace - :test-ns"
 ;; this code block will generate tests under example-md-new-ns-test
 
 (clojure.test/is (= '8 (* 2 4)))))

--- a/test-resources/expected/test-doc-blocks/test/example_md_out_test.clj
+++ b/test-resources/expected/test-doc-blocks/test/example_md_out_test.clj
@@ -4,7 +4,7 @@
             lread.test-doc-blocks.runtime))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 68 - The Basics"
+  (clojure.test/testing  "doc/example.md - line 62 - The Basics"
 ;; A snippit of Clojure where we check result, stderr and stdout
 (let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
   (println "To out I go")
@@ -14,4 +14,30 @@
   (clojure.test/is (= ["To err is human"] (clojure.string/split-lines actual-err)))
   (clojure.test/is (= ["To out I go"] (clojure.string/split-lines actual-out))))))
 
-(defn test-ns-hook [] (block-0001))
+(clojure.test/deftest block-0002
+  (clojure.test/testing  "doc/example.md - line 99 - Multiline Expectations"
+;; A snippit of Clojure where we check result, stderr and stdout
+(let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
+  (println "Hi ho\nHi ho\nTo out I will go")
+  (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine"))
+  (range 1 16)))]
+  (clojure.test/is (= '( 1  2  3  4  5
+     6  7  8  9 10
+    11 12 13 14 15) actual))
+  (clojure.test/is (= ["To err is human" "To forgive" "Is devine"] (clojure.string/split-lines actual-err)))
+  (clojure.test/is (= ["Hi ho" "Hi ho" "To out I will go"] (clojure.string/split-lines actual-out))))))
+
+(clojure.test/deftest block-0003
+  (clojure.test/testing  "doc/example.md - line 119 - Multiline Expectations"
+;; A snippit of Clojure where we check result, stderr and stdout
+(let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
+  (println "Hi ho\nHi ho\nTo out I will go\n=stderr=> still part of stdout")
+  (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine\n=> part of stderr"))
+  [:bip :bop '=stdout> :bap :borp]))]
+  (clojure.test/is (= '[:bip :bop
+     =stdout> :bap
+     :borp] actual))
+  (clojure.test/is (= ["To err is human" "To forgive" "Is devine" "=> part of stderr"] (clojure.string/split-lines actual-err)))
+  (clojure.test/is (= ["Hi ho" "Hi ho" "To out I will go" "=stderr=> still part of stdout"] (clojure.string/split-lines actual-out))))))
+
+(defn test-ns-hook [] (block-0001) (block-0002) (block-0003))

--- a/test-resources/expected/test-doc-blocks/test/example_md_out_test.clj
+++ b/test-resources/expected/test-doc-blocks/test/example_md_out_test.clj
@@ -35,8 +35,8 @@
   (binding [*out* *err*] (println "To err is human\nTo forgive\nIs devine\n=> part of stderr"))
   [:bip :bop '=stdout> :bap :borp]))]
   (clojure.test/is (= '[:bip :bop
-     =stdout> :bap
-     :borp] actual))
+    =stdout> :bap
+    :borp] actual))
   (clojure.test/is (= ["To err is human" "To forgive" "Is devine" "=> part of stderr"] (clojure.string/split-lines actual-err)))
   (clojure.test/is (= ["Hi ho" "Hi ho" "To out I will go" "=stderr=> still part of stdout"] (clojure.string/split-lines actual-out))))))
 

--- a/test-resources/expected/test-doc-blocks/test/example_md_out_test.clj
+++ b/test-resources/expected/test-doc-blocks/test/example_md_out_test.clj
@@ -4,7 +4,7 @@
             lread.test-doc-blocks.runtime))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 58 - The Basics"
+  (clojure.test/testing  "doc/example.md - line 68 - The Basics"
 ;; A snippit of Clojure where we check result, stderr and stdout
 (let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
   (println "To out I go")

--- a/test-resources/expected/test-doc-blocks/test/example_md_out_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_md_out_test.cljs
@@ -4,7 +4,7 @@
             [lread.test-doc-blocks.runtime :include-macros true]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 80 - The Basics"
+  (clojure.test/testing  "doc/example.md - line 73 - The Basics"
 ;; And the same idea for ClojureScript
 (let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
   (println "To out I go")

--- a/test-resources/expected/test-doc-blocks/test/example_md_out_test.cljs
+++ b/test-resources/expected/test-doc-blocks/test/example_md_out_test.cljs
@@ -4,7 +4,7 @@
             [lread.test-doc-blocks.runtime :include-macros true]))
 
 (clojure.test/deftest block-0001
-  (clojure.test/testing  "doc/example.md - line 70 - The Basics"
+  (clojure.test/testing  "doc/example.md - line 80 - The Basics"
 ;; And the same idea for ClojureScript
 (let [[actual actual-out actual-err] (lread.test-doc-blocks.runtime/eval-capture (do
   (println "To out I go")

--- a/test-resources/expected/test-doc-blocks/test/example_md_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_test.cljc
@@ -25,6 +25,12 @@
 ;; test-doc-blocks will generate an assertion to verify (+ 1 2 3 4) evaluates
 ;; to the expected 10
 (clojure.test/is (= '10 (+ 1 2 3 4)))
+;; Expected output can span multiple lines
+(clojure.test/is (= '{:foo :bar
+     :quu :baz} (assoc {} :foo :bar :quu :baz)))
+;; Of if you prefer, without the leading comment character
+(clojure.test/is (= '{:foo :bar
+       :quu :baz} (assoc {} :foo :bar :quu :baz)))
 ;; it understands that Clojure and ClojureScript can evaluate differently
 #?(:clj (clojure.test/is (= '\C \C)))
 #?(:cljs (clojure.test/is (= '"C" \C)))
@@ -37,7 +43,7 @@
   (clojure.test/is (= ["is this right?" "or not?"] (clojure.string/split-lines actual-out))))))
 
 (clojure.test/deftest block-0004
-  (clojure.test/testing  "doc/example.md - line 84 - The Basics"
+  (clojure.test/testing  "doc/example.md - line 94 - The Basics"
 (->> "here we are only checking that our code will run"
      reverse
      reverse
@@ -47,7 +53,7 @@
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0005
-  (clojure.test/testing  "doc/example.md - line 143 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.md - line 153 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:clj
 (do
 ;; This code block will be wrapped in a #?(:clj (do ...))
@@ -60,7 +66,7 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0006
-  (clojure.test/testing  "doc/example.md - line 153 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.md - line 163 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:cljs
 (do
 ;; This code block will be wrapped in a #?(:cljs (do ...))
@@ -72,18 +78,18 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0007
-  (clojure.test/testing  "doc/example.md - line 161 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.md - line 171 - Wrap Test in a Reader Conditional - :reader-cond"
 ;; And our generic cljc code:
 (clojure.test/is (= '[1 2 3] (read-string "[1 2 3]")))))
 
 (clojure.test/deftest ^:testing-meta123 block-0008
-  (clojure.test/testing  "doc/example.md - line 255 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.md - line 265 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata {:testing-meta123 true}
 
 (clojure.test/is (= '[[:a 1]] (into [] {:a 1})))))
 
 (clojure.test/deftest ^{:testing-meta123 "a-specific-value", :testing-meta789 :yip} block-0009
-  (clojure.test/testing  "doc/example.md - line 266 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.md - line 276 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata:
 ;;  {:testing-meta123 "a-specific-value" :testing-meta789 :yip}
 
@@ -94,28 +100,28 @@ nil
    ["oh" "my" "goodness"])))))
 
 (clojure.test/deftest block-0010
-  (clojure.test/testing  "doc/example.md - line 305 - Applying Options - :apply"
+  (clojure.test/testing  "doc/example.md - line 315 - Applying Options - :apply"
 ;; A test will be generated for this code block
 (clojure.test/is (= '"don't skip me!" (apply str (interpose " " ["don't" "skip" "me!"]))))))
 
 (clojure.test/deftest block-0011
-  (clojure.test/testing  "doc/example.md - line 321 - Applying Options - :apply"
+  (clojure.test/testing  "doc/example.md - line 331 - Applying Options - :apply"
 ;; A test will be generated for this code block
 (clojure.test/is (= '"test me by default" (apply str (interpose " " ["test" "me" "by" "default"]))))))
 
 (clojure.test/deftest block-0012
-  (clojure.test/testing  "doc/example.md - line 335 - Section Titles"
+  (clojure.test/testing  "doc/example.md - line 345 - Section Titles"
 nil
 
 (clojure.test/is (= '"well!how!about!that" (string/join "!" ["well" "how" "about" "that"])))))
 
 (clojure.test/deftest block-0013
-  (clojure.test/testing  "doc/example.md - line 349 - Indented Blocks"
+  (clojure.test/testing  "doc/example.md - line 359 - Indented Blocks"
 ;; we handle simple cases a-OK.
 (clojure.test/is (= '6 (+ 1 2 3)))))
 
 (clojure.test/deftest block-0014
-  (clojure.test/testing  "doc/example.md - line 357 - Indented Blocks"
+  (clojure.test/testing  "doc/example.md - line 367 - Indented Blocks"
 ;; we handle indented wrapped strings just fine
 (def s "my
 goodness
@@ -125,14 +131,14 @@ gracious")
   (clojure.test/is (= ["my" "goodness" "gracious"] (clojure.string/split-lines actual-out))))))
 
 (clojure.test/deftest block-0015
-  (clojure.test/testing  "doc/example.md - line 448 - Test Run Order"
+  (clojure.test/testing  "doc/example.md - line 458 - Test Run Order"
 (defn fn-block1 [] (+ 1 2 3))
 
 ; test-doc-blocks dummy assertion to appease tools that fail on no assertions
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0016
-  (clojure.test/testing  "doc/example.md - line 453 - Test Run Order"
+  (clojure.test/testing  "doc/example.md - line 463 - Test Run Order"
 ;; and we continue in this block
 
 (def var-block2 (+ 4 5 6))
@@ -140,7 +146,7 @@ gracious")
 (clojure.test/is (= '21 (+ (fn-block1) var-block2)))))
 
 (clojure.test/deftest block-0017
-  (clojure.test/testing  "doc/example.md - line 463 - Test Run Order"
+  (clojure.test/testing  "doc/example.md - line 473 - Test Run Order"
 (clojure.test/is (= '100 (+ (fn-block1) var-block2 79)))))
 
 (defn test-ns-hook [] (block-0001) (block-0002) (block-0003) (block-0004) (block-0005) (block-0006) (block-0007) (block-0008) (block-0009) (block-0010) (block-0011) (block-0012) (block-0013) (block-0014) (block-0015) (block-0016) (block-0017))

--- a/test-resources/expected/test-doc-blocks/test/example_md_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_test.cljc
@@ -25,12 +25,9 @@
 ;; test-doc-blocks will generate an assertion to verify (+ 1 2 3 4) evaluates
 ;; to the expected 10
 (clojure.test/is (= '10 (+ 1 2 3 4)))
-;; Expected output can span multiple lines
+;; the expected value can span multiple lines
 (clojure.test/is (= '{:foo :bar
-     :quu :baz} (assoc {} :foo :bar :quu :baz)))
-;; Or if you prefer, without the leading comment character
-(clojure.test/is (= '{:foo :bar
-       :quu :baz} (assoc {} :foo :bar :quu :baz)))
+    :quu :baz} (assoc {} :foo :bar :quu :baz)))
 ;; it understands that Clojure and ClojureScript can evaluate differently
 #?(:clj (clojure.test/is (= '\C \C)))
 #?(:cljs (clojure.test/is (= '"C" \C)))
@@ -43,7 +40,7 @@
   (clojure.test/is (= ["is this right?" "or not?"] (clojure.string/split-lines actual-out))))))
 
 (clojure.test/deftest block-0004
-  (clojure.test/testing  "doc/example.md - line 94 - The Basics"
+  (clojure.test/testing  "doc/example.md - line 87 - The Basics"
 (->> "here we are only checking that our code will run"
      reverse
      reverse
@@ -53,7 +50,7 @@
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0005
-  (clojure.test/testing  "doc/example.md - line 153 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.md - line 191 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:clj
 (do
 ;; This code block will be wrapped in a #?(:clj (do ...))
@@ -66,7 +63,7 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0006
-  (clojure.test/testing  "doc/example.md - line 163 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.md - line 201 - Wrap Test in a Reader Conditional - :reader-cond"
 #?(:cljs
 (do
 ;; This code block will be wrapped in a #?(:cljs (do ...))
@@ -78,18 +75,18 @@ nil
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0007
-  (clojure.test/testing  "doc/example.md - line 171 - Wrap Test in a Reader Conditional - :reader-cond"
+  (clojure.test/testing  "doc/example.md - line 209 - Wrap Test in a Reader Conditional - :reader-cond"
 ;; And our generic cljc code:
 (clojure.test/is (= '[1 2 3] (read-string "[1 2 3]")))))
 
 (clojure.test/deftest ^:testing-meta123 block-0008
-  (clojure.test/testing  "doc/example.md - line 265 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.md - line 303 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata {:testing-meta123 true}
 
 (clojure.test/is (= '[[:a 1]] (into [] {:a 1})))))
 
 (clojure.test/deftest ^{:testing-meta123 "a-specific-value", :testing-meta789 :yip} block-0009
-  (clojure.test/testing  "doc/example.md - line 276 - Specifying Metadata - :meta"
+  (clojure.test/testing  "doc/example.md - line 314 - Specifying Metadata - :meta"
 ;; this code block will generate a test with metadata:
 ;;  {:testing-meta123 "a-specific-value" :testing-meta789 :yip}
 
@@ -100,28 +97,28 @@ nil
    ["oh" "my" "goodness"])))))
 
 (clojure.test/deftest block-0010
-  (clojure.test/testing  "doc/example.md - line 315 - Applying Options - :apply"
+  (clojure.test/testing  "doc/example.md - line 353 - Applying Options - :apply"
 ;; A test will be generated for this code block
 (clojure.test/is (= '"don't skip me!" (apply str (interpose " " ["don't" "skip" "me!"]))))))
 
 (clojure.test/deftest block-0011
-  (clojure.test/testing  "doc/example.md - line 331 - Applying Options - :apply"
+  (clojure.test/testing  "doc/example.md - line 369 - Applying Options - :apply"
 ;; A test will be generated for this code block
 (clojure.test/is (= '"test me by default" (apply str (interpose " " ["test" "me" "by" "default"]))))))
 
 (clojure.test/deftest block-0012
-  (clojure.test/testing  "doc/example.md - line 345 - Section Titles"
+  (clojure.test/testing  "doc/example.md - line 383 - Section Titles"
 nil
 
 (clojure.test/is (= '"well!how!about!that" (string/join "!" ["well" "how" "about" "that"])))))
 
 (clojure.test/deftest block-0013
-  (clojure.test/testing  "doc/example.md - line 359 - Indented Blocks"
+  (clojure.test/testing  "doc/example.md - line 397 - Indented Blocks"
 ;; we handle simple cases a-OK.
 (clojure.test/is (= '6 (+ 1 2 3)))))
 
 (clojure.test/deftest block-0014
-  (clojure.test/testing  "doc/example.md - line 367 - Indented Blocks"
+  (clojure.test/testing  "doc/example.md - line 405 - Indented Blocks"
 ;; we handle indented wrapped strings just fine
 (def s "my
 goodness
@@ -131,14 +128,14 @@ gracious")
   (clojure.test/is (= ["my" "goodness" "gracious"] (clojure.string/split-lines actual-out))))))
 
 (clojure.test/deftest block-0015
-  (clojure.test/testing  "doc/example.md - line 458 - Test Run Order"
+  (clojure.test/testing  "doc/example.md - line 496 - Test Run Order"
 (defn fn-block1 [] (+ 1 2 3))
 
 ; test-doc-blocks dummy assertion to appease tools that fail on no assertions
 (clojure.test/is (= '"dummy" "dummy"))))
 
 (clojure.test/deftest block-0016
-  (clojure.test/testing  "doc/example.md - line 463 - Test Run Order"
+  (clojure.test/testing  "doc/example.md - line 501 - Test Run Order"
 ;; and we continue in this block
 
 (def var-block2 (+ 4 5 6))
@@ -146,7 +143,7 @@ gracious")
 (clojure.test/is (= '21 (+ (fn-block1) var-block2)))))
 
 (clojure.test/deftest block-0017
-  (clojure.test/testing  "doc/example.md - line 473 - Test Run Order"
+  (clojure.test/testing  "doc/example.md - line 511 - Test Run Order"
 (clojure.test/is (= '100 (+ (fn-block1) var-block2 79)))))
 
 (defn test-ns-hook [] (block-0001) (block-0002) (block-0003) (block-0004) (block-0005) (block-0006) (block-0007) (block-0008) (block-0009) (block-0010) (block-0011) (block-0012) (block-0013) (block-0014) (block-0015) (block-0016) (block-0017))

--- a/test-resources/expected/test-doc-blocks/test/example_md_test.cljc
+++ b/test-resources/expected/test-doc-blocks/test/example_md_test.cljc
@@ -28,7 +28,7 @@
 ;; Expected output can span multiple lines
 (clojure.test/is (= '{:foo :bar
      :quu :baz} (assoc {} :foo :bar :quu :baz)))
-;; Of if you prefer, without the leading comment character
+;; Or if you prefer, without the leading comment character
 (clojure.test/is (= '{:foo :bar
        :quu :baz} (assoc {} :foo :bar :quu :baz)))
 ;; it understands that Clojure and ClojureScript can evaluate differently

--- a/test/lread/test_doc_blocks/impl/body_prep_test.clj
+++ b/test/lread/test_doc_blocks/impl/body_prep_test.clj
@@ -86,6 +86,9 @@
     ;; comment characters
     (is (= "=> {:foo :bar\n:baz :quu}\n"
            (sut/prep-block-for-conversion-to-test ";; => {:foo :bar\n;:baz :quu}\n"))))
+  (testing "Editor style multiline blocks can use more than one leading comment characted"
+    (is (= "=> {:foo :bar\n:baz :quu}\n"
+           (sut/prep-block-for-conversion-to-test ";; => {:foo :bar\n;;:baz :quu}\n"))))
   (testing "Editor style multiline blocks without leading comments"
     (is (= "=> {:foo :bar\n:baz :quu}\n"
            (sut/prep-block-for-conversion-to-test ";; => {:foo :bar\n:baz :quu}\n"))))

--- a/test/lread/test_doc_blocks/impl/body_prep_test.clj
+++ b/test/lread/test_doc_blocks/impl/body_prep_test.clj
@@ -80,6 +80,15 @@
                                                                        ";      line2    "]))))    )) )
 
 (deftest comment-handling
+  (testing "Editor style multiline blocks removes leading comments"
+    ;; The part of code that is rewriting these blocks as test cases expects the assertion symbol
+    ;; `=>` to be on its own line and the following expectation on a separate line without leading
+    ;; comment characters
+    (is (= "=> {:foo :bar\n:baz :quu}\n"
+           (sut/prep-block-for-conversion-to-test ";; => {:foo :bar\n;:baz :quu}\n"))))
+  (testing "Editor style multiline blocks without leading comments"
+    (is (= "=> {:foo :bar\n:baz :quu}\n"
+           (sut/prep-block-for-conversion-to-test ";; => {:foo :bar\n:baz :quu}\n"))))
   (testing "missing ;; is ok for assertion"
     (is (= "=stdout=> [\"hello there\"]\n"
            (sut/prep-block-for-conversion-to-test "=stdout=> hello there"))))

--- a/test/lread/test_doc_blocks/impl/body_prep_test.clj
+++ b/test/lread/test_doc_blocks/impl/body_prep_test.clj
@@ -107,7 +107,36 @@
     (is (= ";=stdout=> hello there\n"
            (sut/prep-block-for-conversion-to-test ";=stdout=> hello there")))
     (is (= ";;;=stdout=> hello there\n"
-           (sut/prep-block-for-conversion-to-test ";;;=stdout=> hello there"))) ))
+           (sut/prep-block-for-conversion-to-test ";;;=stdout=> hello there"))))
+  (testing "Mixing stdout and editor style assertions"
+    (is (= "(do (println \"When do I end?
+=> 77\")
+    42)
+=stdout=> [\"When do I end?\" \"=> 77\"]
+=> 42
+"
+           (sut/prep-block-for-conversion-to-test "(do (println \"When do I end?\n=> 77\")
+    42)
+;; =stdout=> When do I end?
+; => 77
+;; => 42
+")))
+
+    (is (= "[:when :do :i '=stdout=> (inc 41) :end?]
+=> [:when
+:do
+:i
+=stdout=> 42
+:end?]
+
+"
+           (sut/prep-block-for-conversion-to-test "[:when :do :i '=stdout=> (inc 41) :end?]
+   ;; => [:when
+   ; :do
+   ; :i
+   ; =stdout=> 42
+   ; :end?]
+  ")))))
 
 (deftest larger-test
   (is (= ["Testing 123"

--- a/test/lread/test_doc_blocks/impl/body_prep_test.clj
+++ b/test/lread/test_doc_blocks/impl/body_prep_test.clj
@@ -104,12 +104,11 @@
   (testing "missing ;; is ok for assertion"
     (is (= "=stdout=> [\"hello there\"]\n"
            (sut/prep-block-for-conversion-to-test "=stdout=> hello there"))))
-  (testing "no conversion when assertion token line does not startw with ;;"
+  (testing "no conversion when assertion token line does not start with ;;"
     (is (= ";=stdout=> hello there\n"
            (sut/prep-block-for-conversion-to-test ";=stdout=> hello there")))
     (is (= ";;;=stdout=> hello there\n"
-           (sut/prep-block-for-conversion-to-test ";;;=stdout=> hello there"))))
-  )
+           (sut/prep-block-for-conversion-to-test ";;;=stdout=> hello there")))))
 
 (deftest multiline-expectations-test
   (testing "pass-thru editor-style"

--- a/test/lread/test_doc_blocks/impl/body_prep_test.clj
+++ b/test/lread/test_doc_blocks/impl/body_prep_test.clj
@@ -13,7 +13,15 @@
             (string/join "\n"
                          [";; =stdout=> line1"
                           "; line2"
-                          "; line3"])))))
+                          "; line3"]))))
+
+    ;; Should not matter how many leading comments are used
+    (is (= "=stdout=> [\"line1\" \"line2\" \"line3\"]\n"
+           (sut/prep-block-for-conversion-to-test
+            (string/join "\n"
+                         [";; =stdout=> line1"
+                          ";; line2"
+                          ";; line3"])))))
   (testing "multiple lines, first line in block"
     (is (= "=stdout=> [\"line1\" \"line2\" \"line3\"]\n"
            (sut/prep-block-for-conversion-to-test
@@ -118,6 +126,10 @@
           "=> 42"
           "=stdout=> [\"some stdout\" \"continue stdout\"]"
           "=stderr=> [\"some stderr goes\" \"here and\" \"here\"]"
+          ""
+          "(assoc {} :foo :bar :baz :quu)"
+          "=> {:foo :bar"
+          "    :baz :quu}"
           "That is all"]
          (string/split-lines
           (sut/prep-block-for-conversion-to-test
@@ -141,4 +153,8 @@
                               "; some stderr goes"
                               "; here and"
                               "; here"
+                              ""
+                              "(assoc {} :foo :bar :baz :quu)"
+                              ";; => {:foo :bar"
+                              ";;     :baz :quu}"
                               "That is all"]))))))


### PR DESCRIPTION
Fixes #33 

Allows both old style and new style
```Clojure
   ;; Expected output can span multiple lines
   (assoc {} :foo :bar :quu :baz)
   ;; => {:foo :bar
   ;      :quu :baz}

   ;; One can use multiple leading semicolons as well
   (assoc {} :foo :bar :quu :baz)
   ;; => {:foo :bar
   ;;     :quu :baz}

   ;; Or if you prefer, without the leading comment character
   (assoc {} :foo :bar :quu :baz)
   ;; => {:foo :bar
          :quu :baz}
```

Looking at the example above one can see the value of leading comments, as the examples written like that are rendered more nicely.